### PR TITLE
DG-70 | Fix build error

### DIFF
--- a/src/data/mockDatasets.ts
+++ b/src/data/mockDatasets.ts
@@ -1,0 +1,1 @@
+export { mockDatasets } from "./dataset";


### PR DESCRIPTION
Build fails because Docker’s case-sensitive resolver was looking for @/data/mockDatasets, but no module existed at that path even though local macOS tolerated it; production build bailed before finishing
Added src/data/mockDatasets.ts that re-exports mockDatasets from dataset.ts, so both import variants resolve without touching other code paths
Verified stability via pnpm run type-check, pnpm test, and pnpm run build