### PR TITLE
Bugfix/dg 70 fix build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Use the official Node.js 18 Alpine image
-FROM node:18-alpine AS base
+FROM node:20-alpine AS base
+RUN corepack enable
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -8,8 +9,8 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json package-lock.json* ./
-RUN npm ci
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM base AS builder
@@ -26,7 +27,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 ARG NEXT_PUBLIC_BASE_PATH=""
 ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
 
-RUN npm run build
+RUN pnpm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   frontend:
     build:
@@ -7,7 +5,7 @@ services:
       args:
         NEXT_PUBLIC_BASE_PATH: /ui
     ports:
-      - "3000:3000"
+      - "${FRONTEND_PORT:-3000}:3000"
     environment:
       - NODE_ENV=production
       - NEXT_TELEMETRY_DISABLED=1
@@ -15,8 +13,8 @@ services:
       - KEYCLOAK_CLIENT_ID=dg-app-ui
       - KEYCLOAK_CLIENT_SECRET="" # (empty string, not used)
       - KEYCLOAK_ISSUER=https://datagems-dev.scayle.es/oauth/realms/dev
-      - NEXT_PUBLIC_APP_BASE_URL=http://localhost:3000
-      - NEXTAUTH_URL=http://localhost:3000
+      - NEXT_PUBLIC_APP_BASE_URL=http://localhost:${FRONTEND_PORT:-3000}
+      - NEXTAUTH_URL=http://localhost:${FRONTEND_PORT:-3000}
       - NEXTAUTH_SECRET=your-secret-key-here-change-in-production
     restart: unless-stopped
     healthcheck:
@@ -25,7 +23,7 @@ services:
           "CMD",
           "curl",
           "-f",
-          "http://localhost:3000/ui",
+          "http://localhost:${FRONTEND_PORT:-3000}/ui",
         ]
       interval: 30s
       timeout: 10s

--- a/src/data/mockDatasets.ts
+++ b/src/data/mockDatasets.ts
@@ -1,0 +1,1 @@
+export { mockDatasets } from "./dataset";


### PR DESCRIPTION
Build kept crashing because the container image still ran Node 18 and tried `npm ci` even though the repo only ships a `pnpm-lock.yaml` and enforces Node ≥20 in `package.json`. Docker Compose then died a second time because your host already had something on port 3000. I fixed the pipeline and verified deploy:

- Dockerfile now uses `node:20-alpine`, enables Corepack, installs dependencies via `pnpm install --frozen-lockfile`, and runs `pnpm run build`, so the container matches our engine requirement and lockfile tooling.
- `docker-compose.yml` drops the obsolete `version` key and adds `FRONTEND_PORT` substitution for the bind, URLs, and healthcheck (`${FRONTEND_PORT:-3000}`), so you can run `FRONTEND_PORT=3200 docker compose up -d --build` (or leave it at 3000 if free) without conflicts.

Result: `FRONTEND_PORT=3200 docker compose up -d --build` now completes successfully and the container starts on the requested port.