### PR TITLE
DG-69|Small fixes

### DIFF
--- a/src/components/Browse/Browse.test.tsx
+++ b/src/components/Browse/Browse.test.tsx
@@ -178,11 +178,11 @@ describe("Browse - Delete Collection Feature", () => {
     });
   });
 
-  it("should call deleteUserCollection API and show success toast", async () => {
+  it("should call deleteCollection API and show success toast", async () => {
     const mockGetCollectionGrants = vi
       .fn()
       .mockResolvedValue(["dg_col-delete"]);
-    const mockDeleteUserCollection = vi.fn().mockResolvedValue({});
+    const mockDeleteCollection = vi.fn().mockResolvedValue({});
     const mockRefreshExtraCollections = vi.fn();
     const mockNotifyCollectionModified = vi.fn();
     const mockPush = vi.fn();
@@ -190,7 +190,7 @@ describe("Browse - Delete Collection Feature", () => {
     mockUseApi.mockReturnValue({
       hasToken: true,
       getCollectionGrants: mockGetCollectionGrants,
-      deleteUserCollection: mockDeleteUserCollection,
+      deleteCollection: mockDeleteCollection,
     });
 
     mockUseRouter.mockReturnValue({
@@ -231,7 +231,7 @@ describe("Browse - Delete Collection Feature", () => {
     await userEvent.click(confirmDeleteButton);
 
     await waitFor(() => {
-      expect(mockDeleteUserCollection).toHaveBeenCalledWith("123");
+      expect(mockDeleteCollection).toHaveBeenCalledWith("123");
       expect(mockRefreshExtraCollections).toHaveBeenCalled();
       expect(mockNotifyCollectionModified).toHaveBeenCalled();
     });
@@ -247,14 +247,14 @@ describe("Browse - Delete Collection Feature", () => {
     const mockGetCollectionGrants = vi
       .fn()
       .mockResolvedValue(["dg_col-delete"]);
-    const mockDeleteUserCollection = vi
+    const mockDeleteCollection = vi
       .fn()
       .mockRejectedValue(new Error("API Error"));
 
     mockUseApi.mockReturnValue({
       hasToken: true,
       getCollectionGrants: mockGetCollectionGrants,
-      deleteUserCollection: mockDeleteUserCollection,
+      deleteCollection: mockDeleteCollection,
     });
 
     render(

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -258,6 +258,11 @@ export function useApi() {
 
   const getCollectionGrants = useCallback(
     async (collectionId: string): Promise<string[]> => {
+      logApiRequest("getCollectionGrants", {
+        endpoint: `/principal/me/context-grants/collection?id=${collectionId}`,
+        collectionId,
+      });
+
       const response = await makeRequest(
         `/principal/me/context-grants/collection?id=${collectionId}`,
         {
@@ -266,10 +271,16 @@ export function useApi() {
       );
 
       if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        logApiError("getCollectionGrants", errorData, { collectionId });
         return [];
       }
 
       const data = await response.json();
+      logApiResponse("getCollectionGrants", {
+        collectionId,
+        grants: data.grants || [],
+      });
       return data.grants || [];
     },
     [makeRequest],
@@ -299,7 +310,7 @@ export function useApi() {
     [makeRequest],
   );
 
-  const deleteUserCollection = useCallback(
+  const deleteCollection = useCallback(
     async (collectionId: string): Promise<any> => {
       logApiRequest("deleteCollection", {
         endpoint: `/collection/${collectionId}`,
@@ -316,9 +327,11 @@ export function useApi() {
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
         logApiError("deleteCollection", errorData, { collectionId });
-        throw new Error(
-          errorData.error || ApiErrorMessage.DELETE_COLLECTION_FAILED,
-        );
+        const errorMessage =
+          errorData.error ||
+          errorData.message ||
+          ApiErrorMessage.DELETE_COLLECTION_FAILED;
+        throw new Error(errorMessage);
       }
 
       logApiResponse("deleteCollection", { collectionId });
@@ -603,7 +616,7 @@ export function useApi() {
     removeDatasetFromUserCollection,
     getCollectionGrants,
     grantCollectionPermission,
-    deleteUserCollection,
+    deleteCollection,
     searchInDataExplore,
     searchCrossDataset,
     getConversation,


### PR DESCRIPTION
- Renamed deleteUserCollection function to deleteCollection to remove user collection concept from naming
- Added logging to getCollectionGrants function for request, response, and error tracking
- Improved error handling in deleteCollection to show more detailed error messages
- Simplified delete permission check logic to always show Delete Collection button for custom collections except Favorites
- Removed upfront grant checking for delete button visibility - API will validate permissions on deletion attempt
- Updated all test files to use new deleteCollection function name instead of deleteUserCollection
- Fixed all API endpoints to use /collection/... instead of /user/collection/... for consistency
- Added debug logging to track collection grant checks and deletion attempts
- Ensured Delete Collection button appears in three-dot menu for all custom collections except Favorites collection
- All endpoints now correctly use collection endpoints as collections not user collections per API design