### PR TITLE
Feature/dg 87 add tests to chat components

### DIFF
--- a/src/components/ui/chat/tests/AIMessage.test.tsx
+++ b/src/components/ui/chat/tests/AIMessage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Message } from "@/types/chat";
 import { AIMessage } from "../AIMessage";
 
@@ -52,6 +52,10 @@ describe("AIMessage", () => {
     latitude: 10,
     longitude: 20,
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("should render header, temperature map and content", () => {
     render(<AIMessage message={defaultMessage} />);

--- a/src/components/ui/chat/tests/AIMessage.test.tsx
+++ b/src/components/ui/chat/tests/AIMessage.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Message } from "@/types/chat";
+import { AIMessage } from "../AIMessage";
+
+vi.mock("@ui/chat/AIMessageHeader", () => ({
+  AIMessageHeader: ({
+    sources,
+    onSourcesClick,
+  }: {
+    sources?: number;
+    onSourcesClick?: () => void;
+  }) => (
+    <div
+      data-testid="ai-message-header"
+      data-sources={sources}
+      onClick={onSourcesClick}
+    >
+      Header
+    </div>
+  ),
+}));
+
+vi.mock("@ui/chat/TemperatureMap", () => ({
+  TemperatureMap: () => (
+    <div data-testid="temperature-map">Temperature Map</div>
+  ),
+}));
+
+vi.mock("@ui/chat/AIMessageContent", () => ({
+  AIMessageContent: ({
+    content,
+    tableData,
+  }: {
+    content: string;
+    tableData?: unknown;
+  }) => (
+    <div data-testid="ai-message-content">
+      {content}
+      {tableData ? <span data-testid="has-table-data">Has table</span> : null}
+    </div>
+  ),
+}));
+
+describe("AIMessage", () => {
+  const defaultMessage: Message = {
+    id: "1",
+    type: "ai",
+    content: "Test content",
+    timestamp: new Date().toISOString(),
+    latitude: 10,
+    longitude: 20,
+  };
+
+  it("should render header, temperature map and content", () => {
+    render(<AIMessage message={defaultMessage} />);
+
+    expect(screen.getByTestId("ai-message-header")).toBeInTheDocument();
+    expect(screen.getByTestId("temperature-map")).toBeInTheDocument();
+    expect(screen.getByTestId("ai-message-content")).toHaveTextContent(
+      "Test content",
+    );
+  });
+
+  it("should render message content correctly", () => {
+    const message: Message = {
+      ...defaultMessage,
+      content: "Custom message content",
+    };
+
+    render(<AIMessage message={message} />);
+
+    expect(screen.getByText("Custom message content")).toBeInTheDocument();
+  });
+
+  it("should pass tableData to AIMessageContent when provided", () => {
+    const messageWithTable: Message = {
+      ...defaultMessage,
+      tableData: {
+        columns: [{ columnNumber: 1, name: "A" }],
+        rows: [
+          {
+            rowNumber: 1,
+            cells: [{ column: "A", value: "1" }],
+          },
+        ],
+      },
+    };
+
+    render(<AIMessage message={messageWithTable} />);
+
+    expect(screen.getByTestId("has-table-data")).toBeInTheDocument();
+  });
+
+  it("should pass sources to header when provided", () => {
+    const messageWithSources: Message = {
+      ...defaultMessage,
+      sources: 3,
+    };
+
+    render(<AIMessage message={messageWithSources} />);
+
+    const header = screen.getByTestId("ai-message-header");
+    expect(header).toHaveAttribute("data-sources", "3");
+  });
+
+  it("should call onSourcesClick when header sources button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSourcesClick = vi.fn();
+    const messageWithSources: Message = {
+      ...defaultMessage,
+      sources: 2,
+    };
+
+    render(
+      <AIMessage
+        message={messageWithSources}
+        onSourcesClick={onSourcesClick}
+      />,
+    );
+
+    const header = screen.getByTestId("ai-message-header");
+    await user.click(header);
+
+    expect(onSourcesClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render temperature map for messages with coordinates", () => {
+    render(<AIMessage message={defaultMessage} />);
+
+    expect(screen.getByTestId("temperature-map")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/chat/tests/AIMessageContent.test.tsx
+++ b/src/components/ui/chat/tests/AIMessageContent.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TableData } from "@/types/chat";
+import { AIMessageContent } from "../AIMessageContent";
+
+vi.mock("@ui/chat/DataTable", () => ({
+  DataTable: ({ tableData }: { tableData: TableData }) => (
+    <div data-testid="data-table" role="table">
+      {JSON.stringify(tableData)}
+    </div>
+  ),
+}));
+
+describe("AIMessageContent", () => {
+  const defaultProps = {
+    content: "Hello world",
+  };
+
+  it("should render message content", () => {
+    render(<AIMessageContent {...defaultProps} />);
+
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+
+  it("should render DataTable when tableData is provided", () => {
+    const tableData: TableData = {
+      columns: [
+        { columnNumber: 1, name: "Col1" },
+        { columnNumber: 2, name: "Col2" },
+      ],
+      rows: [
+        {
+          rowNumber: 1,
+          cells: [
+            { column: "Col1", value: "A" },
+            { column: "Col2", value: "B" },
+          ],
+        },
+        {
+          rowNumber: 2,
+          cells: [
+            { column: "Col1", value: "C" },
+            { column: "Col2", value: "D" },
+          ],
+        },
+      ],
+    };
+
+    render(<AIMessageContent content="With table" tableData={tableData} />);
+
+    const table = screen.getByTestId("data-table");
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveAttribute("role", "table");
+    expect(table.textContent).toContain("Col1");
+    expect(table.textContent).toContain("Col2");
+  });
+
+  it("should not render DataTable when tableData is not provided", () => {
+    render(<AIMessageContent {...defaultProps} />);
+
+    expect(screen.queryByTestId("data-table")).not.toBeInTheDocument();
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+
+  it("should render both content and table when both are provided", () => {
+    const tableData: TableData = {
+      columns: [{ columnNumber: 1, name: "Col1" }],
+      rows: [
+        {
+          rowNumber: 1,
+          cells: [{ column: "Col1", value: "A" }],
+        },
+      ],
+    };
+
+    render(<AIMessageContent content="Test content" tableData={tableData} />);
+
+    expect(screen.getByText("Test content")).toBeInTheDocument();
+    expect(screen.getByTestId("data-table")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/chat/tests/AIMessageContent.test.tsx
+++ b/src/components/ui/chat/tests/AIMessageContent.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TableData } from "@/types/chat";
 import { AIMessageContent } from "../AIMessageContent";
 
@@ -15,6 +15,10 @@ describe("AIMessageContent", () => {
   const defaultProps = {
     content: "Hello world",
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("should render message content", () => {
     render(<AIMessageContent {...defaultProps} />);

--- a/src/components/ui/chat/tests/AIMessageHeader.test.tsx
+++ b/src/components/ui/chat/tests/AIMessageHeader.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AIMessageHeader } from "../AIMessageHeader";
 
 describe("AIMessageHeader", () => {
@@ -8,6 +8,10 @@ describe("AIMessageHeader", () => {
     sources: undefined,
     onSourcesClick: undefined,
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("should render title and download button", () => {
     render(<AIMessageHeader {...defaultProps} />);

--- a/src/components/ui/chat/tests/AIMessageHeader.test.tsx
+++ b/src/components/ui/chat/tests/AIMessageHeader.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AIMessageHeader } from "../AIMessageHeader";
+
+describe("AIMessageHeader", () => {
+  const defaultProps = {
+    sources: undefined,
+    onSourcesClick: undefined,
+  };
+
+  it("should render title and download button", () => {
+    render(<AIMessageHeader {...defaultProps} />);
+
+    expect(screen.getByText("DataGems AI")).toBeInTheDocument();
+
+    const downloadButton = screen.getByRole("button", { name: /download/i });
+    expect(downloadButton).toBeInTheDocument();
+    expect(downloadButton).toBeDisabled();
+  });
+
+  it("should render sources button when sources > 0", () => {
+    render(<AIMessageHeader sources={3} />);
+
+    const sourcesButton = screen.getByRole("button", { name: /3 sources/i });
+    expect(sourcesButton).toBeInTheDocument();
+  });
+
+  it("should render singular label when sources === 1", () => {
+    render(<AIMessageHeader sources={1} />);
+
+    const sourcesButton = screen.getByRole("button", { name: /1 source/i });
+    expect(sourcesButton).toBeInTheDocument();
+  });
+
+  it("should not render sources button when sources is 0 or undefined", () => {
+    const { rerender } = render(<AIMessageHeader />);
+
+    expect(
+      screen.queryByRole("button", { name: /source/i }),
+    ).not.toBeInTheDocument();
+
+    rerender(<AIMessageHeader sources={0} />);
+    expect(
+      screen.queryByRole("button", { name: /source/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should call onSourcesClick when sources button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSourcesClick = vi.fn();
+
+    render(<AIMessageHeader sources={2} onSourcesClick={onSourcesClick} />);
+
+    const sourcesButton = screen.getByRole("button", { name: /2 sources/i });
+    await user.click(sourcesButton);
+
+    expect(onSourcesClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render both download and sources buttons when sources are provided", () => {
+    render(<AIMessageHeader sources={5} />);
+
+    expect(
+      screen.getByRole("button", { name: /download/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /5 sources/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/chat/tests/AIResponseSkeleton.test.tsx
+++ b/src/components/ui/chat/tests/AIResponseSkeleton.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AIResponseSkeleton } from "../AIResponseSkeleton";
 
 describe("AIResponseSkeleton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should render the skeleton component", () => {
     const { container } = render(<AIResponseSkeleton />);
 

--- a/src/components/ui/chat/tests/AIResponseSkeleton.test.tsx
+++ b/src/components/ui/chat/tests/AIResponseSkeleton.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AIResponseSkeleton } from "../AIResponseSkeleton";
+
+describe("AIResponseSkeleton", () => {
+  it("should render the skeleton component", () => {
+    const { container } = render(<AIResponseSkeleton />);
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("should render skeleton loading placeholders with animation", () => {
+    const { container } = render(<AIResponseSkeleton />);
+
+    const animatedElements = container.querySelectorAll(
+      "[class*='animate-pulse']",
+    );
+    expect(animatedElements.length).toBeGreaterThan(0);
+  });
+
+  it("should render multiple skeleton lines for content", () => {
+    const { container } = render(<AIResponseSkeleton />);
+
+    const skeletonElements = container.querySelectorAll("[class*='bg-slate']");
+    expect(skeletonElements.length).toBeGreaterThan(3);
+  });
+
+  it("should render header and content sections", () => {
+    const { container } = render(<AIResponseSkeleton />);
+
+    const mainContainer = container.firstChild as HTMLElement;
+    expect(mainContainer).toBeInTheDocument();
+    expect(mainContainer.children.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/ui/chat/tests/ChatHistoryList.test.tsx
+++ b/src/components/ui/chat/tests/ChatHistoryList.test.tsx
@@ -1,0 +1,522 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatHistoryList } from "../ChatHistoryList";
+
+const mockUseApi = vi.fn();
+
+vi.mock("@/hooks/useApi", () => ({
+  useApi: () => mockUseApi(),
+}));
+
+vi.mock("../ChatItem", () => ({
+  ChatItem: ({
+    conversation,
+    isActive,
+    onConversationUpdate,
+    onDeleteConversation,
+  }: {
+    conversation: { id: string; name?: string };
+    isActive: boolean;
+    onConversationUpdate?: (
+      id: string,
+      newName: string,
+      newETag?: string,
+    ) => void;
+    onDeleteConversation?: (id: string, name: string) => void;
+  }) => (
+    <div data-testid={`chat-item-${conversation.id}`}>
+      <span>{conversation.name || "Untitled Conversation"}</span>
+      {isActive && <span data-testid="active-indicator">Active</span>}
+      <button
+        data-testid={`update-${conversation.id}`}
+        onClick={() =>
+          onConversationUpdate?.(conversation.id, "New Name", "new-etag")
+        }
+      >
+        Update
+      </button>
+      <button
+        data-testid={`delete-${conversation.id}`}
+        onClick={() =>
+          onDeleteConversation?.(
+            conversation.id,
+            conversation.name || "Untitled",
+          )
+        }
+      >
+        Delete
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("../Search", () => ({
+  Search: ({
+    placeholder,
+    value,
+    onChange,
+    onSearch,
+    onClear,
+  }: {
+    placeholder?: string;
+    value?: string;
+    onChange?: (value: string) => void;
+    onSearch?: (value: string) => void;
+    onClear?: () => void;
+  }) => (
+    <div data-testid="search-input">
+      <input
+        data-testid="search-field"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange?.(e.target.value)}
+      />
+      <button
+        data-testid="search-button"
+        onClick={() => onSearch?.(value || "")}
+      >
+        Search
+      </button>
+      <button data-testid="clear-button" onClick={() => onClear?.()}>
+        Clear
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("../NoData", () => ({
+  NoData: ({
+    icon: Icon,
+    title,
+    description,
+  }: {
+    icon: unknown;
+    title: string;
+    description?: string;
+  }) => (
+    <div data-testid="no-data">
+      <div data-testid="no-data-title">{title}</div>
+      {description && (
+        <div data-testid="no-data-description">{description}</div>
+      )}
+    </div>
+  ),
+}));
+
+describe("ChatHistoryList", () => {
+  const defaultSession = { user: { id: "user-1" } };
+  const defaultConversations = [
+    {
+      id: "conv-1",
+      name: "First Conversation",
+      eTag: "etag-1",
+      createdAt: "2024-01-01T00:00:00Z",
+      messages: [{ createdAt: "2024-01-01T00:00:00Z" }],
+    },
+    {
+      id: "conv-2",
+      name: "Second Conversation",
+      eTag: "etag-2",
+      createdAt: "2024-01-02T00:00:00Z",
+      messages: [{ createdAt: "2024-01-02T00:00:00Z" }],
+    },
+    {
+      id: "conv-3",
+      name: "Third Conversation",
+      eTag: "etag-3",
+      createdAt: "2024-01-03T00:00:00Z",
+      messages: [{ createdAt: "2024-01-03T00:00:00Z" }],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render loading skeleton when isLoading is true", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi
+        .fn()
+        .mockImplementation(() => new Promise(() => {})),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    const skeleton = document.querySelector(".animate-pulse");
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  it("should render error message when fetch fails", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockRejectedValue(new Error("API Error")),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load chat history"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should not fetch conversations when hasToken is false", async () => {
+    const mockQueryConversations = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: false,
+      queryConversations: mockQueryConversations,
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(mockQueryConversations).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should fetch and render conversations successfully", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: defaultConversations,
+      }),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+      expect(screen.getByTestId("chat-item-conv-2")).toBeInTheDocument();
+      expect(screen.getByTestId("chat-item-conv-3")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("First Conversation")).toBeInTheDocument();
+    expect(screen.getByText("Second Conversation")).toBeInTheDocument();
+    expect(screen.getByText("Third Conversation")).toBeInTheDocument();
+  });
+
+  it("should filter out conversations without messages", async () => {
+    const conversationsWithEmpty = [
+      ...defaultConversations,
+      {
+        id: "conv-empty",
+        name: "Empty Conversation",
+        eTag: "etag-empty",
+        messages: [],
+      },
+      {
+        id: "conv-no-messages",
+        name: "No Messages",
+        eTag: "etag-no-messages",
+      },
+    ];
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: conversationsWithEmpty,
+      }),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId("chat-item-conv-empty"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("chat-item-conv-no-messages"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render empty state when no conversations", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: [],
+      }),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("no-data")).toBeInTheDocument();
+      expect(screen.getByTestId("no-data-title")).toHaveTextContent(
+        "Your Chat history will appear here",
+      );
+      expect(screen.getByTestId("no-data-description")).toHaveTextContent(
+        "Ask a question first",
+      );
+    });
+  });
+
+  it("should filter conversations by search query", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: defaultConversations,
+      }),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByTestId("search-field");
+    await userEvent.type(searchInput, "First");
+
+    const searchButton = screen.getByTestId("search-button");
+    await userEvent.click(searchButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+      expect(screen.queryByTestId("chat-item-conv-2")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("chat-item-conv-3")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should show no results message when search has no matches", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: defaultConversations,
+      }),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByTestId("search-field");
+    await userEvent.type(searchInput, "NonExistent");
+
+    const searchButton = screen.getByTestId("search-button");
+    await userEvent.click(searchButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("no-data")).toBeInTheDocument();
+      expect(screen.getByTestId("no-data-title")).toHaveTextContent(
+        "No results found",
+      );
+      expect(screen.getByTestId("no-data-description")).toHaveTextContent(
+        "Please try different search",
+      );
+    });
+  });
+
+  it("should clear search when clear button is clicked", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: defaultConversations,
+      }),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByTestId("search-field");
+    await userEvent.type(searchInput, "First");
+
+    const clearButton = screen.getByTestId("clear-button");
+    await userEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(searchInput).toHaveValue("");
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+      expect(screen.getByTestId("chat-item-conv-2")).toBeInTheDocument();
+      expect(screen.getByTestId("chat-item-conv-3")).toBeInTheDocument();
+    });
+  });
+
+  it("should mark active conversation correctly", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: defaultConversations,
+      }),
+    });
+
+    render(
+      <ChatHistoryList
+        session={defaultSession}
+        currentConversationId="conv-2"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-2")).toBeInTheDocument();
+    });
+
+    const activeIndicator = screen.getByTestId("active-indicator");
+    expect(activeIndicator).toBeInTheDocument();
+    expect(
+      activeIndicator.closest('[data-testid="chat-item-conv-2"]'),
+    ).toBeTruthy();
+  });
+
+  it("should call onConversationUpdate when conversation is updated", async () => {
+    const mockOnConversationUpdate = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: defaultConversations,
+      }),
+    });
+
+    render(
+      <ChatHistoryList
+        session={defaultSession}
+        onConversationUpdate={mockOnConversationUpdate}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+    });
+
+    const updateButton = screen.getByTestId("update-conv-1");
+    await userEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(mockOnConversationUpdate).toHaveBeenCalledWith(
+        "conv-1",
+        "New Name",
+        "new-etag",
+      );
+    });
+  });
+
+  it("should call onDeleteConversation when conversation is deleted", async () => {
+    const mockOnDeleteConversation = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: defaultConversations,
+      }),
+    });
+
+    render(
+      <ChatHistoryList
+        session={defaultSession}
+        onDeleteConversation={mockOnDeleteConversation}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByTestId("delete-conv-1");
+    await userEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockOnDeleteConversation).toHaveBeenCalledWith(
+        "conv-1",
+        "First Conversation",
+      );
+    });
+  });
+
+  it("should use external conversations when provided", async () => {
+    const externalConversations = [
+      {
+        id: "external-1",
+        name: "External Conversation",
+        eTag: "etag-external-1",
+        createdAt: "2024-01-01T00:00:00Z",
+      },
+    ];
+
+    const setExternalConversations = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: defaultConversations,
+      }),
+    });
+
+    render(
+      <ChatHistoryList
+        session={defaultSession}
+        conversations={externalConversations}
+        setConversations={setExternalConversations}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-external-1")).toBeInTheDocument();
+      expect(screen.getByText("External Conversation")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("chat-item-conv-1")).not.toBeInTheDocument();
+  });
+
+  it("should handle conversations with no name (Untitled)", async () => {
+    const conversationsWithoutName = [
+      {
+        id: "conv-untitled",
+        eTag: "etag-untitled",
+        createdAt: "2024-01-01T00:00:00Z",
+        messages: [{ createdAt: "2024-01-01T00:00:00Z" }],
+      },
+    ];
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: conversationsWithoutName,
+      }),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-untitled")).toBeInTheDocument();
+      expect(screen.getByText("Untitled Conversation")).toBeInTheDocument();
+    });
+  });
+
+  it("should handle search with case-insensitive matching", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryConversations: vi.fn().mockResolvedValue({
+        items: defaultConversations,
+      }),
+    });
+
+    render(<ChatHistoryList session={defaultSession} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByTestId("search-field");
+    await userEvent.type(searchInput, "first");
+
+    const searchButton = screen.getByTestId("search-button");
+    await userEvent.click(searchButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-item-conv-1")).toBeInTheDocument();
+      expect(screen.queryByTestId("chat-item-conv-2")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/chat/tests/ChatInitialView.test.tsx
+++ b/src/components/ui/chat/tests/ChatInitialView.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ChatInitialView from "../ChatInitialView";
+
+vi.mock("@ui/chat/DGIcon", () => ({
+  default: ({ className }: { className?: string }) => (
+    <div data-testid="dg-icon" className={className} aria-label="DataGems Icon">
+      DG Icon
+    </div>
+  ),
+}));
+
+describe("ChatInitialView", () => {
+  it("should render the component with all required elements", () => {
+    render(<ChatInitialView />);
+
+    expect(screen.getByText("New Chat")).toBeInTheDocument();
+    expect(
+      screen.getByText("Ask your question based on added datasets"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("dg-icon")).toBeInTheDocument();
+  });
+
+  it("should render the heading with correct semantic structure", () => {
+    render(<ChatInitialView />);
+
+    const heading = screen.getByRole("heading", { name: "New Chat", level: 1 });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent("New Chat");
+  });
+
+  it("should render the description text", () => {
+    render(<ChatInitialView />);
+
+    const description = screen.getByText(
+      "Ask your question based on added datasets",
+    );
+    expect(description).toBeInTheDocument();
+    expect(description.tagName).toBe("P");
+  });
+
+  it("should render the DG icon", () => {
+    render(<ChatInitialView />);
+
+    const icon = screen.getByTestId("dg-icon");
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("should have accessible structure", () => {
+    render(<ChatInitialView />);
+
+    const heading = screen.getByRole("heading", { name: "New Chat" });
+    expect(heading).toBeInTheDocument();
+
+    const icon = screen.getByLabelText("DataGems Icon");
+    expect(icon).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/chat/tests/ChatInitialView.test.tsx
+++ b/src/components/ui/chat/tests/ChatInitialView.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import ChatInitialView from "../ChatInitialView";
 
 vi.mock("@ui/chat/DGIcon", () => ({
@@ -11,6 +11,10 @@ vi.mock("@ui/chat/DGIcon", () => ({
 }));
 
 describe("ChatInitialView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should render the component with all required elements", () => {
     render(<ChatInitialView />);
 

--- a/src/components/ui/chat/tests/ChatInput.test.tsx
+++ b/src/components/ui/chat/tests/ChatInput.test.tsx
@@ -1,0 +1,296 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Collection } from "@/types/collection";
+import { ChatInput } from "../ChatInput";
+
+const mockCollections = {
+  apiCollections: [] as Collection[],
+  collections: [] as Collection[],
+  extraCollections: [],
+  isLoading: false,
+};
+
+describe("ChatInput", () => {
+  const defaultProps = {
+    value: "",
+    onChange: vi.fn(),
+    onSend: vi.fn(),
+    onAddDatasets: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render textarea with placeholder", () => {
+    render(<ChatInput {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue("");
+  });
+
+  it("should call onChange when typing in textarea", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<ChatInput {...defaultProps} onChange={onChange} />);
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    await user.type(textarea, "Hello");
+
+    expect(onChange).toHaveBeenCalledTimes(5);
+    expect(onChange).toHaveBeenLastCalledWith("Hello");
+  });
+
+  it("should display the value prop in textarea", () => {
+    render(<ChatInput {...defaultProps} value="Test message" />);
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    expect(textarea).toHaveValue("Test message");
+  });
+
+  it("should disable send button when value is empty", () => {
+    render(<ChatInput {...defaultProps} value="" />);
+
+    const sendButton = screen.getByRole("button", { name: "" });
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("should enable send button when value has text", () => {
+    render(<ChatInput {...defaultProps} value="Hello" />);
+
+    const sendButton = screen.getByRole("button", { name: "" });
+    expect(sendButton).not.toBeDisabled();
+  });
+
+  it("should disable send button when value only has whitespace", () => {
+    render(<ChatInput {...defaultProps} value="   " />);
+
+    const sendButton = screen.getByRole("button", { name: "" });
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("should call onSend when send button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+
+    render(<ChatInput {...defaultProps} value="Hello" onSend={onSend} />);
+
+    const sendButton = screen.getByRole("button", { name: "" });
+    await user.click(sendButton);
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onSend when Enter key is pressed", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+
+    render(<ChatInput {...defaultProps} value="Hello" onSend={onSend} />);
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    await user.type(textarea, "{Enter}");
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call onSend when Shift+Enter is pressed", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+
+    render(<ChatInput {...defaultProps} value="Hello" onSend={onSend} />);
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    await user.type(textarea, "{Shift>}{Enter}{/Shift}");
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("should not call onSend when Enter is pressed and input is empty", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+
+    render(<ChatInput {...defaultProps} value="" onSend={onSend} />);
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    await user.type(textarea, "{Enter}");
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("should not call onSend when Enter is pressed and component is disabled", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+
+    render(
+      <ChatInput {...defaultProps} value="Hello" onSend={onSend} disabled />,
+    );
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    await user.type(textarea, "{Enter}");
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("should not call onSend when Enter is pressed and isLoading is true", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+
+    render(
+      <ChatInput
+        {...defaultProps}
+        value="Hello"
+        onSend={onSend}
+        isLoading={true}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    await user.type(textarea, "{Enter}");
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("should show loading spinner when isLoading is true", () => {
+    render(<ChatInput {...defaultProps} isLoading={true} />);
+
+    expect(screen.getByText("Sending...")).toBeInTheDocument();
+  });
+
+  it("should not show send button when isLoading is true", () => {
+    render(<ChatInput {...defaultProps} isLoading={true} />);
+
+    const sendButton = screen.queryByRole("button", { name: "" });
+    expect(sendButton).not.toBeInTheDocument();
+  });
+
+  it("should render CollectionsDropdown when collections and onSelectCollection are provided", () => {
+    const mockOnSelectCollection = vi.fn();
+    const mockSelectedCollection: Collection = {
+      id: "1",
+      name: "Test Collection",
+    };
+
+    render(
+      <ChatInput
+        {...defaultProps}
+        collections={mockCollections}
+        selectedCollection={mockSelectedCollection}
+        onSelectCollection={mockOnSelectCollection}
+      />,
+    );
+
+    // CollectionsDropdown should be rendered (we can't easily test its internals without mocking)
+    // But we can verify the send button is still present
+    const sendButton = screen.getByRole("button", { name: "" });
+    expect(sendButton).toBeInTheDocument();
+  });
+
+  it("should render Collections button when collections are not provided", () => {
+    const mockSelectedCollection: Collection = {
+      id: "1",
+      name: "Test Collection",
+    };
+
+    render(
+      <ChatInput
+        {...defaultProps}
+        selectedCollection={mockSelectedCollection}
+      />,
+    );
+
+    const collectionsButton = screen.getByText("Test Collection");
+    expect(collectionsButton).toBeInTheDocument();
+  });
+
+  it("should render Collections button with default text when no collection is selected", () => {
+    render(<ChatInput {...defaultProps} />);
+
+    const collectionsButton = screen.getByText("Collections");
+    expect(collectionsButton).toBeInTheDocument();
+  });
+
+  it("should call onAddDatasets when Collections button is clicked", async () => {
+    const user = userEvent.setup();
+    const onAddDatasets = vi.fn();
+
+    render(<ChatInput {...defaultProps} onAddDatasets={onAddDatasets} />);
+
+    const collectionsButton = screen.getByText("Collections");
+    await user.click(collectionsButton);
+
+    expect(onAddDatasets).toHaveBeenCalledTimes(1);
+  });
+
+  it("should remove ' Collection' suffix from collection name in button", () => {
+    const mockSelectedCollection: Collection = {
+      id: "1",
+      name: "Test Collection",
+    };
+
+    render(
+      <ChatInput
+        {...defaultProps}
+        selectedCollection={mockSelectedCollection}
+      />,
+    );
+
+    const collectionsButton = screen.getByText("Test");
+    expect(collectionsButton).toBeInTheDocument();
+  });
+
+  it("should display error message when error prop is provided", () => {
+    render(<ChatInput {...defaultProps} error="Test error message" />);
+
+    expect(screen.getByText("Test error message")).toBeInTheDocument();
+  });
+
+  it("should apply error styling when error is present", () => {
+    const { container } = render(
+      <ChatInput {...defaultProps} error="Test error" />,
+    );
+
+    const inputContainer = container.firstChild as HTMLElement;
+    expect(inputContainer).toHaveClass("border-red-550");
+  });
+
+  it("should disable textarea when disabled prop is true", () => {
+    render(<ChatInput {...defaultProps} disabled />);
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    expect(textarea).toBeDisabled();
+  });
+
+  it("should disable send button when disabled prop is true", () => {
+    render(<ChatInput {...defaultProps} value="Hello" disabled />);
+
+    const sendButton = screen.getByRole("button", { name: "" });
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("should disable Collections button when disabled prop is true", () => {
+    render(<ChatInput {...defaultProps} disabled />);
+
+    const collectionsButton = screen.getByText("Collections");
+    expect(collectionsButton.closest("button")).toBeDisabled();
+  });
+
+  it("should have proper name attribute on textarea", () => {
+    render(<ChatInput {...defaultProps} />);
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    expect(textarea).toHaveAttribute("name", "chat-input");
+  });
+
+  it("should have proper accessibility attributes", () => {
+    render(<ChatInput {...defaultProps} value="Hello" />);
+
+    const textarea = screen.getByPlaceholderText("Ask me anything...");
+    expect(textarea).toHaveAttribute("name", "chat-input");
+
+    const sendButton = screen.getByRole("button", { name: "" });
+    expect(sendButton).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/chat/tests/ChatInput.test.tsx
+++ b/src/components/ui/chat/tests/ChatInput.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Collection } from "@/types/collection";

--- a/src/components/ui/chat/tests/ChatItem.test.tsx
+++ b/src/components/ui/chat/tests/ChatItem.test.tsx
@@ -271,7 +271,7 @@ describe("ChatItem", () => {
     const input = screen.getByDisplayValue("Test Conversation");
     await user.clear(input);
     await user.type(input, "Updated Name");
-    await user.tab(); // Blur the input
+    await user.tab();
 
     await waitFor(() => {
       expect(mockUpdateConversation).toHaveBeenCalledWith("conv-1", {
@@ -298,8 +298,7 @@ describe("ChatItem", () => {
     const renameButton = screen.getByText("Rename");
     await user.click(renameButton);
 
-    const input = screen.getByDisplayValue("Test Conversation");
-    await user.tab(); // Blur without changes
+    await user.tab();
 
     await waitFor(() => {
       expect(mockUpdateConversation).not.toHaveBeenCalled();

--- a/src/components/ui/chat/tests/ChatItem.test.tsx
+++ b/src/components/ui/chat/tests/ChatItem.test.tsx
@@ -1,0 +1,576 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatItem } from "../ChatItem";
+
+const mockUseApi = vi.fn();
+
+vi.mock("@/hooks/useApi", () => ({
+  useApi: () => mockUseApi(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/lib/utils", () => ({
+  formatRelativeTime: (date: string) => {
+    return new Date(date).toLocaleDateString();
+  },
+}));
+
+describe("ChatItem", () => {
+  const defaultConversation = {
+    id: "conv-1",
+    name: "Test Conversation",
+    createdAt: "2024-01-01T00:00:00Z",
+    eTag: "etag-123",
+  };
+
+  const defaultProps = {
+    conversation: defaultConversation,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: vi.fn().mockResolvedValue({ eTag: "new-etag-456" }),
+    });
+  });
+
+  it("should render conversation name", () => {
+    render(<ChatItem {...defaultProps} />);
+
+    expect(screen.getByText("Test Conversation")).toBeInTheDocument();
+  });
+
+  it("should render 'Untitled Conversation' when name is not provided", () => {
+    render(
+      <ChatItem
+        {...defaultProps}
+        conversation={{ ...defaultConversation, name: undefined }}
+      />,
+    );
+
+    expect(screen.getByText("Untitled Conversation")).toBeInTheDocument();
+  });
+
+  it("should render formatted creation date", () => {
+    render(<ChatItem {...defaultProps} />);
+
+    expect(screen.getByText(/1\/1\/2024/)).toBeInTheDocument();
+  });
+
+  it("should render empty date when createdAt is not provided", () => {
+    render(
+      <ChatItem
+        {...defaultProps}
+        conversation={{ ...defaultConversation, createdAt: undefined }}
+      />,
+    );
+
+    const dateElement = screen.getByText("");
+    expect(dateElement).toBeInTheDocument();
+  });
+
+  it("should render as Link when not active and not editing", () => {
+    render(<ChatItem {...defaultProps} />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/chat/conv-1");
+  });
+
+  it("should render as div when active", () => {
+    render(<ChatItem {...defaultProps} isActive />);
+
+    const link = screen.queryByRole("link");
+    expect(link).not.toBeInTheDocument();
+  });
+
+  it("should apply active styling when isActive is true", () => {
+    const { container } = render(<ChatItem {...defaultProps} isActive />);
+
+    const item = container.firstChild as HTMLElement;
+    expect(item).toHaveClass("border-blue-300");
+  });
+
+  it("should show dropdown menu button on hover", () => {
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    expect(dropdownButton).toBeInTheDocument();
+  });
+
+  it("should open dropdown menu when menu button is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    expect(screen.getByText("Rename")).toBeInTheDocument();
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+  });
+
+  it("should close dropdown when clicking outside", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <ChatItem {...defaultProps} />
+        <div data-testid="outside">Outside</div>
+      </div>,
+    );
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    expect(screen.getByText("Rename")).toBeInTheDocument();
+
+    const outside = screen.getByTestId("outside");
+    await user.click(outside);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Rename")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should enter edit mode when Rename is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("should focus and select input text when entering edit mode", async () => {
+    const user = userEvent.setup();
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue(
+      "Test Conversation",
+    ) as HTMLInputElement;
+    expect(input).toHaveFocus();
+  });
+
+  it("should save changes when Enter key is pressed", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi
+      .fn()
+      .mockResolvedValue({ eTag: "new-etag-456" });
+    const onConversationUpdate = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(
+      <ChatItem
+        {...defaultProps}
+        onConversationUpdate={onConversationUpdate}
+      />,
+    );
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.clear(input);
+    await user.type(input, "Updated Name{Enter}");
+
+    await waitFor(() => {
+      expect(mockUpdateConversation).toHaveBeenCalledWith("conv-1", {
+        name: "Updated Name",
+        eTag: "etag-123",
+      });
+    });
+
+    await waitFor(() => {
+      expect(onConversationUpdate).toHaveBeenCalledWith(
+        "conv-1",
+        "Updated Name",
+        "new-etag-456",
+      );
+    });
+  });
+
+  it("should cancel edit when Escape key is pressed", async () => {
+    const user = userEvent.setup();
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.type(input, "Changed Name{Escape}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByDisplayValue("Changed Name"),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Test Conversation")).toBeInTheDocument();
+  });
+
+  it("should save changes when input loses focus", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi
+      .fn()
+      .mockResolvedValue({ eTag: "new-etag-456" });
+    const onConversationUpdate = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(
+      <ChatItem
+        {...defaultProps}
+        onConversationUpdate={onConversationUpdate}
+      />,
+    );
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.clear(input);
+    await user.type(input, "Updated Name");
+    await user.tab(); // Blur the input
+
+    await waitFor(() => {
+      expect(mockUpdateConversation).toHaveBeenCalledWith("conv-1", {
+        name: "Updated Name",
+        eTag: "etag-123",
+      });
+    });
+  });
+
+  it("should not save if name is unchanged", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.tab(); // Blur without changes
+
+    await waitFor(() => {
+      expect(mockUpdateConversation).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should not save if name is empty", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.clear(input);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(mockUpdateConversation).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should not save if name exceeds 300 characters", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi.fn();
+    const longName = "a".repeat(301);
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.clear(input);
+    await user.type(input, longName);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(mockUpdateConversation).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should not save if eTag is missing", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(
+      <ChatItem
+        {...defaultProps}
+        conversation={{ ...defaultConversation, eTag: "" }}
+      />,
+    );
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.clear(input);
+    await user.type(input, "New Name");
+    await user.tab();
+
+    await waitFor(() => {
+      expect(mockUpdateConversation).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should not save if hasToken is false", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi.fn();
+
+    mockUseApi.mockReturnValue({
+      hasToken: false,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.clear(input);
+    await user.type(input, "New Name");
+    await user.tab();
+
+    await waitFor(() => {
+      expect(mockUpdateConversation).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should show success toast when update succeeds", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi
+      .fn()
+      .mockResolvedValue({ eTag: "new-etag-456" });
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.clear(input);
+    await user.type(input, "Updated Name{Enter}");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Conversation name updated successfully!"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should show error toast when update fails", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi
+      .fn()
+      .mockRejectedValue(new Error("Update failed"));
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.clear(input);
+    await user.type(input, "Updated Name{Enter}");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to update conversation name"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should call onDeleteConversation when Delete is clicked", async () => {
+    const user = userEvent.setup();
+    const onDeleteConversation = vi.fn();
+
+    render(
+      <ChatItem
+        {...defaultProps}
+        onDeleteConversation={onDeleteConversation}
+      />,
+    );
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const deleteButton = screen.getByText("Delete");
+    await user.click(deleteButton);
+
+    expect(onDeleteConversation).toHaveBeenCalledWith(
+      "conv-1",
+      "Test Conversation",
+    );
+  });
+
+  it("should close dropdown after delete is clicked", async () => {
+    const user = userEvent.setup();
+    const onDeleteConversation = vi.fn();
+
+    render(
+      <ChatItem
+        {...defaultProps}
+        onDeleteConversation={onDeleteConversation}
+      />,
+    );
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const deleteButton = screen.getByText("Delete");
+    await user.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Rename")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should disable input when updating", async () => {
+    const user = userEvent.setup();
+    const mockUpdateConversation = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ eTag: "new-etag-456" }), 100);
+        }),
+    );
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      updateConversation: mockUpdateConversation,
+    });
+
+    render(<ChatItem {...defaultProps} />);
+
+    const dropdownButton = screen.getByRole("button", { name: "" });
+    await user.click(dropdownButton);
+
+    const renameButton = screen.getByText("Rename");
+    await user.click(renameButton);
+
+    const input = screen.getByDisplayValue("Test Conversation");
+    await user.clear(input);
+    await user.type(input, "Updated Name{Enter}");
+
+    await waitFor(() => {
+      expect(input).toBeDisabled();
+    });
+  });
+
+  it("should show tooltip for long conversation names", () => {
+    const longName = "a".repeat(31);
+    render(
+      <ChatItem
+        {...defaultProps}
+        conversation={{ ...defaultConversation, name: longName }}
+      />,
+    );
+
+    expect(screen.getByText(longName)).toBeInTheDocument();
+  });
+
+  it("should not show tooltip for short conversation names", () => {
+    render(<ChatItem {...defaultProps} />);
+
+    const nameElement = screen.getByText("Test Conversation");
+    expect(nameElement).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/chat/tests/ChatMessages.test.tsx
+++ b/src/components/ui/chat/tests/ChatMessages.test.tsx
@@ -1,0 +1,342 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Message } from "@/types/chat";
+import ChatMessages from "../ChatMessages";
+
+vi.mock("../MessageItem", () => ({
+  default: ({ message }: { message: Message }) => (
+    <div data-testid={`message-${message.id}`}>
+      {message.type}: {message.content}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/scrollUtils", () => ({
+  scrollToBottom: vi.fn(),
+}));
+
+describe("ChatMessages", () => {
+  const createRef = () => ({
+    current: document.createElement("div"),
+  });
+
+  const defaultProps = {
+    messages: [] as Message[],
+    isMessagesLoading: false,
+    messagesEndRef: createRef(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render empty state when no messages", () => {
+    render(<ChatMessages {...defaultProps} />);
+
+    expect(screen.queryByTestId(/message-/)).not.toBeInTheDocument();
+  });
+
+  it("should render user message", () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        type: "user",
+        content: "Hello",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+    ];
+
+    render(<ChatMessages {...defaultProps} messages={messages} />);
+
+    expect(screen.getByTestId("message-1")).toBeInTheDocument();
+    expect(screen.getByText("user: Hello")).toBeInTheDocument();
+  });
+
+  it("should render AI message", () => {
+    const messages: Message[] = [
+      {
+        id: "2",
+        type: "ai",
+        content: "Hi there!",
+        timestamp: "2024-01-01T00:00:01Z",
+      },
+    ];
+
+    render(<ChatMessages {...defaultProps} messages={messages} />);
+
+    expect(screen.getByTestId("message-2")).toBeInTheDocument();
+    expect(screen.getByText("ai: Hi there!")).toBeInTheDocument();
+  });
+
+  it("should render multiple messages", () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        type: "user",
+        content: "Hello",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "2",
+        type: "ai",
+        content: "Hi there!",
+        timestamp: "2024-01-01T00:00:01Z",
+      },
+      {
+        id: "3",
+        type: "user",
+        content: "How are you?",
+        timestamp: "2024-01-01T00:00:02Z",
+      },
+    ];
+
+    render(<ChatMessages {...defaultProps} messages={messages} />);
+
+    expect(screen.getByTestId("message-1")).toBeInTheDocument();
+    expect(screen.getByTestId("message-2")).toBeInTheDocument();
+    expect(screen.getByTestId("message-3")).toBeInTheDocument();
+  });
+
+  it("should sort messages by timestamp in ascending order", () => {
+    const messages: Message[] = [
+      {
+        id: "3",
+        type: "user",
+        content: "Third",
+        timestamp: "2024-01-01T00:00:02Z",
+      },
+      {
+        id: "1",
+        type: "user",
+        content: "First",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "2",
+        type: "user",
+        content: "Second",
+        timestamp: "2024-01-01T00:00:01Z",
+      },
+    ];
+
+    render(<ChatMessages {...defaultProps} messages={messages} />);
+
+    const messageElements = screen.getAllByTestId(/message-/);
+    expect(messageElements[0]).toHaveAttribute("data-testid", "message-1");
+    expect(messageElements[1]).toHaveAttribute("data-testid", "message-2");
+    expect(messageElements[2]).toHaveAttribute("data-testid", "message-3");
+  });
+
+  it("should sort messages with Date objects correctly", () => {
+    const messages: Message[] = [
+      {
+        id: "2",
+        type: "user",
+        content: "Second",
+        timestamp: new Date("2024-01-01T00:00:01Z"),
+      },
+      {
+        id: "1",
+        type: "user",
+        content: "First",
+        timestamp: new Date("2024-01-01T00:00:00Z"),
+      },
+    ];
+
+    render(<ChatMessages {...defaultProps} messages={messages} />);
+
+    const messageElements = screen.getAllByTestId(/message-/);
+    expect(messageElements[0]).toHaveAttribute("data-testid", "message-1");
+    expect(messageElements[1]).toHaveAttribute("data-testid", "message-2");
+  });
+
+  it("should sort messages with mixed Date and string timestamps", () => {
+    const messages: Message[] = [
+      {
+        id: "2",
+        type: "user",
+        content: "Second",
+        timestamp: "2024-01-01T00:00:01Z",
+      },
+      {
+        id: "1",
+        type: "user",
+        content: "First",
+        timestamp: new Date("2024-01-01T00:00:00Z"),
+      },
+    ];
+
+    render(<ChatMessages {...defaultProps} messages={messages} />);
+
+    const messageElements = screen.getAllByTestId(/message-/);
+    expect(messageElements[0]).toHaveAttribute("data-testid", "message-1");
+    expect(messageElements[1]).toHaveAttribute("data-testid", "message-2");
+  });
+
+  it("should show loading spinner when isGeneratingAIResponse is true", () => {
+    render(<ChatMessages {...defaultProps} isGeneratingAIResponse={true} />);
+
+    expect(screen.getByText("Generating response...")).toBeInTheDocument();
+  });
+
+  it("should not show loading spinner when isGeneratingAIResponse is false", () => {
+    render(<ChatMessages {...defaultProps} isGeneratingAIResponse={false} />);
+
+    expect(
+      screen.queryByText("Generating response..."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not show loading spinner when isGeneratingAIResponse is undefined", () => {
+    render(<ChatMessages {...defaultProps} />);
+
+    expect(
+      screen.queryByText("Generating response..."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render messagesEndRef div", () => {
+    const messagesEndRef = createRef();
+    const { container } = render(
+      <ChatMessages {...defaultProps} messagesEndRef={messagesEndRef} />,
+    );
+
+    const refDiv = container.querySelector("div:last-child");
+    expect(refDiv).toBeInTheDocument();
+  });
+
+  it("should apply correct padding classes when showSelectedPanel is true", () => {
+    const { container } = render(
+      <ChatMessages {...defaultProps} showSelectedPanel={true} />,
+    );
+
+    const messagesContainer = container.firstChild as HTMLElement;
+    expect(messagesContainer).toHaveClass("px-4", "py-4");
+  });
+
+  it("should apply correct padding classes when showSelectedPanel is false", () => {
+    const { container } = render(
+      <ChatMessages {...defaultProps} showSelectedPanel={false} />,
+    );
+
+    const messagesContainer = container.firstChild as HTMLElement;
+    expect(messagesContainer).toHaveClass("px-0", "lg:px-0", "py-0", "lg:py-0");
+  });
+
+  it("should apply correct padding classes when showSelectedPanel is undefined", () => {
+    const { container } = render(<ChatMessages {...defaultProps} />);
+
+    const messagesContainer = container.firstChild as HTMLElement;
+    expect(messagesContainer).toHaveClass("px-0", "lg:px-0", "py-0", "lg:py-0");
+  });
+
+  it("should pass onSourcesClick to MessageItem", () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        type: "ai",
+        content: "Test",
+        timestamp: "2024-01-01T00:00:00Z",
+        sources: 3,
+      },
+    ];
+
+    const onSourcesClick = vi.fn();
+
+    render(
+      <ChatMessages
+        {...defaultProps}
+        messages={messages}
+        onSourcesClick={onSourcesClick}
+      />,
+    );
+
+    expect(screen.getByTestId("message-1")).toBeInTheDocument();
+  });
+
+  it("should handle messages with all optional fields", () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        type: "ai",
+        content: "Test",
+        timestamp: "2024-01-01T00:00:00Z",
+        sources: 5,
+        relatedDatasetIds: ["dataset-1"],
+        datasetIds: ["dataset-2"],
+        latitude: 10.5,
+        longitude: 20.5,
+        tableData: {
+          columns: [{ columnNumber: 1, name: "A" }],
+          rows: [
+            {
+              rowNumber: 1,
+              cells: [{ column: "A", value: "1" }],
+            },
+          ],
+        },
+      },
+    ];
+
+    render(<ChatMessages {...defaultProps} messages={messages} />);
+
+    expect(screen.getByTestId("message-1")).toBeInTheDocument();
+  });
+
+  it("should maintain message order when timestamps are identical", () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        type: "user",
+        content: "First",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "2",
+        type: "user",
+        content: "Second",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+    ];
+
+    render(<ChatMessages {...defaultProps} messages={messages} />);
+
+    const messageElements = screen.getAllByTestId(/message-/);
+    expect(messageElements).toHaveLength(2);
+  });
+
+  it("should handle empty messages array with loading spinner", () => {
+    render(
+      <ChatMessages
+        {...defaultProps}
+        messages={[]}
+        isGeneratingAIResponse={true}
+      />,
+    );
+
+    expect(screen.getByText("Generating response...")).toBeInTheDocument();
+  });
+
+  it("should handle messages with microsecond precision timestamps", () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        type: "user",
+        content: "First",
+        timestamp: "2024-01-01T00:00:00.000001Z",
+      },
+      {
+        id: "2",
+        type: "user",
+        content: "Second",
+        timestamp: "2024-01-01T00:00:00.000000Z",
+      },
+    ];
+
+    render(<ChatMessages {...defaultProps} messages={messages} />);
+
+    const messageElements = screen.getAllByTestId(/message-/);
+    expect(messageElements[0]).toHaveAttribute("data-testid", "message-2");
+    expect(messageElements[1]).toHaveAttribute("data-testid", "message-1");
+  });
+});

--- a/src/components/ui/chat/tests/ChatMessagesSkeleton.test.tsx
+++ b/src/components/ui/chat/tests/ChatMessagesSkeleton.test.tsx
@@ -1,0 +1,13 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ChatMessagesSkeleton } from "../ChatMessagesSkeleton";
+
+describe("ChatMessagesSkeleton", () => {
+  it("should render skeleton structure with multiple elements", () => {
+    const { container } = render(<ChatMessagesSkeleton />);
+
+    const mainContainer = container.firstChild as HTMLElement;
+    expect(mainContainer).toBeInTheDocument();
+    expect(mainContainer.children.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/ui/chat/tests/ChatMessagesSkeleton.test.tsx
+++ b/src/components/ui/chat/tests/ChatMessagesSkeleton.test.tsx
@@ -1,8 +1,12 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatMessagesSkeleton } from "../ChatMessagesSkeleton";
 
 describe("ChatMessagesSkeleton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should render skeleton structure with multiple elements", () => {
     const { container } = render(<ChatMessagesSkeleton />);
 

--- a/src/components/ui/chat/tests/DGIcon.test.tsx
+++ b/src/components/ui/chat/tests/DGIcon.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import DGIcon from "../DGIcon";
+
+describe("DGIcon", () => {
+  it("should render an SVG element", () => {
+    const { container } = render(<DGIcon />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("should render with default size of 24", () => {
+    const { container } = render(<DGIcon />);
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "24");
+    expect(svg).toHaveAttribute("height", "24");
+  });
+
+  it("should render with custom size when provided", () => {
+    const { container } = render(<DGIcon size={48} />);
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "48");
+    expect(svg).toHaveAttribute("height", "48");
+  });
+});

--- a/src/components/ui/chat/tests/DGIcon.test.tsx
+++ b/src/components/ui/chat/tests/DGIcon.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import DGIcon from "../DGIcon";
 
 describe("DGIcon", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should render an SVG element", () => {
     const { container } = render(<DGIcon />);
     const svg = container.querySelector("svg");

--- a/src/components/ui/chat/tests/DataTable.test.tsx
+++ b/src/components/ui/chat/tests/DataTable.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { TableData } from "@/types/chat";
+import { DataTable } from "../DataTable";
+
+vi.mock("../Button", () => ({
+  Button: ({
+    children,
+    onClick,
+    variant,
+    size,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    variant?: string;
+    size?: string;
+  }) => (
+    <button
+      onClick={onClick}
+      data-variant={variant}
+      data-size={size}
+      data-testid="show-more-button"
+    >
+      {children}
+    </button>
+  ),
+}));
+
+describe("DataTable", () => {
+  const createMockTableData = (
+    columns: string[],
+    rowCount: number,
+  ): TableData => {
+    return {
+      columns: columns.map((name, index) => ({
+        columnNumber: index + 1,
+        name,
+      })),
+      rows: Array.from({ length: rowCount }, (_, rowIndex) => ({
+        rowNumber: rowIndex + 1,
+        cells: columns.map((col) => ({
+          column: col,
+          value: `value-${rowIndex + 1}-${col}`,
+        })),
+      })),
+    };
+  };
+
+  it("should render table with columns and rows", () => {
+    const tableData = createMockTableData(["name", "age"], 2);
+
+    render(<DataTable tableData={tableData} />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Age")).toBeInTheDocument();
+    expect(screen.getByText("value-1-name")).toBeInTheDocument();
+    expect(screen.getByText("value-1-age")).toBeInTheDocument();
+    expect(screen.getByText("value-2-name")).toBeInTheDocument();
+    expect(screen.getByText("value-2-age")).toBeInTheDocument();
+  });
+
+  it("should format date values correctly", () => {
+    const tableData: TableData = {
+      columns: [{ columnNumber: 1, name: "date" }],
+      rows: [
+        {
+          rowNumber: 1,
+          cells: [
+            {
+              column: "date",
+              value: "2026-01-08T10:30:00",
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<DataTable tableData={tableData} />);
+
+    const dateCell = screen.getByText(/Jan 8, 2026/i);
+    expect(dateCell).toBeInTheDocument();
+  });
+
+  it("should show only first 20 rows by default", () => {
+    const tableData = createMockTableData(["column"], 25);
+
+    render(<DataTable tableData={tableData} />);
+
+    expect(screen.getByText("value-1-column")).toBeInTheDocument();
+    expect(screen.getByText("value-20-column")).toBeInTheDocument();
+    expect(screen.queryByText("value-21-column")).not.toBeInTheDocument();
+  });
+
+  it("should show 'Show more' button when there are more than 20 rows", () => {
+    const tableData = createMockTableData(["column"], 25);
+
+    render(<DataTable tableData={tableData} />);
+
+    const showMoreButton = screen.getByTestId("show-more-button");
+    expect(showMoreButton).toBeInTheDocument();
+    expect(showMoreButton).toHaveTextContent(/Show more.*5 more rows/i);
+  });
+
+  it("should not show 'Show more' button when there are 20 or fewer rows", () => {
+    const tableData = createMockTableData(["column"], 20);
+
+    render(<DataTable tableData={tableData} />);
+
+    expect(screen.queryByTestId("show-more-button")).not.toBeInTheDocument();
+  });
+
+  it("should show all rows when 'Show more' button is clicked", async () => {
+    const user = userEvent.setup();
+    const tableData = createMockTableData(["column"], 25);
+
+    render(<DataTable tableData={tableData} />);
+
+    const showMoreButton = screen.getByTestId("show-more-button");
+    await user.click(showMoreButton);
+
+    expect(screen.getByText("value-1-column")).toBeInTheDocument();
+    expect(screen.getByText("value-25-column")).toBeInTheDocument();
+  });
+
+  it("should show 'Show less' button after expanding", async () => {
+    const user = userEvent.setup();
+    const tableData = createMockTableData(["column"], 25);
+
+    render(<DataTable tableData={tableData} />);
+
+    const showMoreButton = screen.getByTestId("show-more-button");
+    await user.click(showMoreButton);
+
+    const showLessButton = screen.getByTestId("show-more-button");
+    expect(showLessButton).toHaveTextContent(/Show less.*20 rows/i);
+  });
+
+  it("should collapse rows when 'Show less' button is clicked", async () => {
+    const user = userEvent.setup();
+    const tableData = createMockTableData(["column"], 25);
+
+    render(<DataTable tableData={tableData} />);
+
+    const showMoreButton = screen.getByTestId("show-more-button");
+    await user.click(showMoreButton);
+
+    const showLessButton = screen.getByTestId("show-more-button");
+    await user.click(showLessButton);
+
+    expect(screen.getByText("value-1-column")).toBeInTheDocument();
+    expect(screen.getByText("value-20-column")).toBeInTheDocument();
+    expect(screen.queryByText("value-21-column")).not.toBeInTheDocument();
+  });
+
+  it("should handle table with no rows", () => {
+    const tableData: TableData = {
+      columns: [{ columnNumber: 1, name: "column" }],
+      rows: [],
+    };
+
+    render(<DataTable tableData={tableData} />);
+
+    expect(screen.getByText("Column")).toBeInTheDocument();
+    expect(screen.queryByTestId("show-more-button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/chat/tests/DataTable.test.tsx
+++ b/src/components/ui/chat/tests/DataTable.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TableData } from "@/types/chat";
 import { DataTable } from "../DataTable";
 
@@ -47,6 +47,10 @@ describe("DataTable", () => {
       })),
     };
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("should render table with columns and rows", () => {
     const tableData = createMockTableData(["name", "age"], 2);

--- a/src/components/ui/chat/tests/DatasetChangeWarning.test.tsx
+++ b/src/components/ui/chat/tests/DatasetChangeWarning.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import DatasetChangeWarning from "../DatasetChangeWarning";
 
 vi.mock("lucide-react", () => ({
@@ -11,6 +11,10 @@ vi.mock("lucide-react", () => ({
 }));
 
 describe("DatasetChangeWarning", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should not render when isVisible is false", () => {
     const { container } = render(<DatasetChangeWarning isVisible={false} />);
 

--- a/src/components/ui/chat/tests/DatasetChangeWarning.test.tsx
+++ b/src/components/ui/chat/tests/DatasetChangeWarning.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import DatasetChangeWarning from "../DatasetChangeWarning";
+
+vi.mock("lucide-react", () => ({
+  Info: ({ className }: { className?: string }) => (
+    <svg data-testid="info-icon" className={className} aria-label="Info icon">
+      Info
+    </svg>
+  ),
+}));
+
+describe("DatasetChangeWarning", () => {
+  it("should not render when isVisible is false", () => {
+    const { container } = render(<DatasetChangeWarning isVisible={false} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render when isVisible is true", () => {
+    render(<DatasetChangeWarning isVisible={true} />);
+
+    expect(
+      screen.getByText(
+        "The selected datasets have changed. The AI will respond based on the updated list.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should render Info icon", () => {
+    render(<DatasetChangeWarning isVisible={true} />);
+
+    const icon = screen.getByTestId("info-icon");
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("should display warning message", () => {
+    render(<DatasetChangeWarning isVisible={true} />);
+
+    const message = screen.getByText(/The selected datasets have changed/i);
+    expect(message).toBeInTheDocument();
+    expect(message).toHaveTextContent(
+      "The selected datasets have changed. The AI will respond based on the updated list.",
+    );
+  });
+});

--- a/src/components/ui/chat/tests/LoadingSpinner.test.tsx
+++ b/src/components/ui/chat/tests/LoadingSpinner.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LoadingSpinner } from "../LoadingSpinner";
 
 describe("LoadingSpinner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should render loading message and spinner", () => {
     render(<LoadingSpinner />);
 

--- a/src/components/ui/chat/tests/LoadingSpinner.test.tsx
+++ b/src/components/ui/chat/tests/LoadingSpinner.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LoadingSpinner } from "../LoadingSpinner";
+
+describe("LoadingSpinner", () => {
+  it("should render loading message and spinner", () => {
+    render(<LoadingSpinner />);
+
+    const loadingText = screen.getByText("Loading messages...");
+    expect(loadingText).toBeInTheDocument();
+    expect(loadingText).toBeVisible();
+  });
+});

--- a/src/components/ui/chat/tests/MessageItem.test.tsx
+++ b/src/components/ui/chat/tests/MessageItem.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Message } from "@/types/chat";
 import MessageItem from "../MessageItem";
 
@@ -42,6 +42,10 @@ describe("MessageItem", () => {
     content: "I'm doing well, thank you!",
     timestamp: new Date().toISOString(),
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("should render UserMessage for user type messages", () => {
     render(<MessageItem message={defaultUserMessage} />);

--- a/src/components/ui/chat/tests/MessageItem.test.tsx
+++ b/src/components/ui/chat/tests/MessageItem.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Message } from "@/types/chat";
+import MessageItem from "../MessageItem";
+
+vi.mock("../AIMessage", () => ({
+  AIMessage: ({
+    message,
+    onSourcesClick,
+  }: {
+    message: Message;
+    onSourcesClick?: () => void;
+  }) => (
+    <div
+      data-testid="ai-message"
+      data-message-id={message.id}
+      onClick={onSourcesClick}
+    >
+      AI Message: {message.content}
+    </div>
+  ),
+}));
+
+vi.mock("../UserMessage", () => ({
+  UserMessage: ({ content }: { content: string }) => (
+    <div data-testid="user-message">User Message: {content}</div>
+  ),
+}));
+
+describe("MessageItem", () => {
+  const defaultUserMessage: Message = {
+    id: "user-1",
+    type: "user",
+    content: "Hello, how are you?",
+    timestamp: new Date().toISOString(),
+  };
+
+  const defaultAIMessage: Message = {
+    id: "ai-1",
+    type: "ai",
+    content: "I'm doing well, thank you!",
+    timestamp: new Date().toISOString(),
+  };
+
+  it("should render UserMessage for user type messages", () => {
+    render(<MessageItem message={defaultUserMessage} />);
+
+    expect(screen.getByTestId("user-message")).toBeInTheDocument();
+    expect(
+      screen.getByText("User Message: Hello, how are you?"),
+    ).toBeInTheDocument();
+  });
+
+  it("should render AIMessage for ai type messages", () => {
+    render(<MessageItem message={defaultAIMessage} />);
+
+    expect(screen.getByTestId("ai-message")).toBeInTheDocument();
+    expect(screen.getByText("I'm doing well, thank you!")).toBeInTheDocument();
+  });
+
+  it("should pass message content to UserMessage", () => {
+    const message: Message = {
+      ...defaultUserMessage,
+      content: "Custom user message",
+    };
+
+    render(<MessageItem message={message} />);
+
+    expect(
+      screen.getByText("User Message: Custom user message"),
+    ).toBeInTheDocument();
+  });
+
+  it("should pass message to AIMessage with correct id", () => {
+    const message: Message = {
+      ...defaultAIMessage,
+      id: "ai-custom-123",
+      content: "Custom AI response",
+    };
+
+    render(<MessageItem message={message} />);
+
+    const aiMessage = screen.getByTestId("ai-message");
+    expect(aiMessage).toHaveAttribute("data-message-id", "ai-custom-123");
+    expect(aiMessage).toHaveTextContent("Custom AI response");
+  });
+
+  it("should call onSourcesClick with message id when provided for AI messages", async () => {
+    const user = userEvent.setup();
+    const onSourcesClick = vi.fn();
+    const message: Message = {
+      ...defaultAIMessage,
+      id: "ai-123",
+    };
+
+    render(<MessageItem message={message} onSourcesClick={onSourcesClick} />);
+
+    const aiMessage = screen.getByTestId("ai-message");
+    await user.click(aiMessage);
+
+    expect(onSourcesClick).toHaveBeenCalledTimes(1);
+    expect(onSourcesClick).toHaveBeenCalledWith("ai-123");
+  });
+
+  it("should not call onSourcesClick when not provided", async () => {
+    const user = userEvent.setup();
+
+    render(<MessageItem message={defaultAIMessage} />);
+
+    const aiMessage = screen.getByTestId("ai-message");
+    await user.click(aiMessage);
+
+    expect(aiMessage).toBeInTheDocument();
+  });
+
+  it("should render with correct message structure", () => {
+    const messageWithAllFields: Message = {
+      id: "ai-full",
+      type: "ai",
+      content: "Full message",
+      timestamp: new Date().toISOString(),
+      sources: 5,
+      latitude: 40.7128,
+      longitude: -74.006,
+      tableData: {
+        columns: [{ columnNumber: 1, name: "A" }],
+        rows: [
+          {
+            rowNumber: 1,
+            cells: [{ column: "A", value: "1" }],
+          },
+        ],
+      },
+    };
+
+    render(<MessageItem message={messageWithAllFields} />);
+
+    expect(screen.getByTestId("ai-message")).toBeInTheDocument();
+    expect(screen.getByText("Full message")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/chat/tests/TemperatureMap.test.tsx
+++ b/src/components/ui/chat/tests/TemperatureMap.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TableData } from "@/types/chat";
+import { TemperatureMap } from "../TemperatureMap";
+
+const mockMapInstance = {
+  setCenter: vi.fn(),
+  setStyle: vi.fn(),
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+  project: vi.fn(() => ({ x: 0, y: 0 })),
+  unproject: vi.fn(() => ({ lng: 0, lat: 0 })),
+  getSource: vi.fn(),
+  getLayer: vi.fn(),
+  addSource: vi.fn(),
+  addLayer: vi.fn(),
+  removeSource: vi.fn(),
+  removeLayer: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+  isStyleLoaded: vi.fn(() => true),
+  remove: vi.fn(),
+};
+
+const mockMapLibre = {
+  Map: vi.fn(() => mockMapInstance),
+};
+
+vi.mock("maplibre-gl", () => ({
+  default: mockMapLibre,
+}));
+
+vi.mock("@ui/Button", () => ({
+  Button: ({
+    children,
+    onClick,
+    "aria-label": ariaLabel,
+    variant,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    "aria-label"?: string;
+    variant?: string;
+  }) => (
+    <button
+      onClick={onClick}
+      aria-label={ariaLabel}
+      data-variant={variant}
+      data-testid={ariaLabel ? `button-${ariaLabel}` : "button"}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+describe("TemperatureMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should not render when latitude is not provided", () => {
+    const { container } = render(
+      <TemperatureMap content="Test content" longitude={-74.006} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should not render when longitude is not provided", () => {
+    const { container } = render(
+      <TemperatureMap content="Test content" latitude={40.7128} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render map with controls when both coordinates are provided", () => {
+    render(
+      <TemperatureMap
+        content="Test content"
+        latitude={40.7128}
+        longitude={-74.006}
+      />,
+    );
+
+    expect(mockMapLibre.Map).toHaveBeenCalled();
+    const calls = mockMapLibre.Map.mock.calls as unknown as Array<
+      Array<{ center: [number, number]; zoom: number }>
+    >;
+    expect(calls.length).toBeGreaterThan(0);
+    const mapCall = calls[0]?.[0];
+    expect(mapCall).toBeDefined();
+    if (mapCall) {
+      expect(mapCall.center).toEqual([-74.006, 40.7128]);
+      expect(mapCall.zoom).toBe(10);
+    }
+
+    expect(screen.getByText("Map")).toBeInTheDocument();
+    expect(screen.getByText("Satellite")).toBeInTheDocument();
+    expect(screen.getByTestId("button-Zoom in")).toBeInTheDocument();
+    expect(screen.getByTestId("button-Zoom out")).toBeInTheDocument();
+  });
+
+  it("should call zoomIn when zoom in button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <TemperatureMap
+        content="Test content"
+        latitude={40.7128}
+        longitude={-74.006}
+      />,
+    );
+
+    const zoomInButton = screen.getByTestId("button-Zoom in");
+    await user.click(zoomInButton);
+
+    expect(mockMapInstance.zoomIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render attribution text", () => {
+    render(
+      <TemperatureMap
+        content="Test content"
+        latitude={40.7128}
+        longitude={-74.006}
+      />,
+    );
+
+    expect(
+      screen.getByText("© OpenStreetMap contributors"),
+    ).toBeInTheDocument();
+  });
+
+  it("should accept optional props and render with defaults", () => {
+    const tableData: TableData = {
+      columns: [{ columnNumber: 1, name: "A" }],
+      rows: [
+        {
+          rowNumber: 1,
+          cells: [{ column: "A", value: "1" }],
+        },
+      ],
+    };
+    const heatColors = ["#0000ff", "#00ff00", "#ff0000"];
+
+    const { rerender } = render(
+      <TemperatureMap
+        content="Test content"
+        latitude={40.7128}
+        longitude={-74.006}
+      />,
+    );
+    expect(mockMapLibre.Map).toHaveBeenCalled();
+
+    rerender(
+      <TemperatureMap
+        content="Test content"
+        latitude={40.7128}
+        longitude={-74.006}
+        baseRadius={200}
+        heatOpacity={0.8}
+        heatColors={heatColors}
+        tableData={tableData}
+      />,
+    );
+    expect(mockMapLibre.Map).toHaveBeenCalled();
+  });
+
+  it("should update map center when coordinates change", () => {
+    const { rerender } = render(
+      <TemperatureMap
+        content="Test content"
+        latitude={40.7128}
+        longitude={-74.006}
+      />,
+    );
+
+    rerender(
+      <TemperatureMap
+        content="Test content"
+        latitude={51.5074}
+        longitude={-0.1278}
+      />,
+    );
+
+    expect(mockMapInstance.setCenter).toHaveBeenCalledWith([-0.1278, 51.5074]);
+  });
+});

--- a/src/components/ui/chat/tests/UserMessage.test.tsx
+++ b/src/components/ui/chat/tests/UserMessage.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UserMessage } from "../UserMessage";
+
+const mockUseSession = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+vi.mock("../Avatar", () => ({
+  Avatar: ({
+    name,
+    email,
+  }: {
+    name?: string;
+    email?: string;
+    src?: string;
+    size?: string;
+    className?: string;
+  }) => (
+    <div data-testid="avatar" data-name={name} data-email={email}>
+      Avatar
+    </div>
+  ),
+}));
+
+describe("UserMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render message content", () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          name: "Test User",
+          email: "test@example.com",
+        },
+      },
+    });
+
+    render(<UserMessage content="Hello, world!" />);
+
+    expect(screen.getByText("Hello, world!")).toBeInTheDocument();
+  });
+
+  it("should render Avatar component", () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          name: "Test User",
+          email: "test@example.com",
+        },
+      },
+    });
+
+    render(<UserMessage content="Test message" />);
+
+    const avatar = screen.getByTestId("avatar");
+    expect(avatar).toBeInTheDocument();
+  });
+
+  it("should pass user name to Avatar when session has name", () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          name: "John Doe",
+          email: "john@example.com",
+        },
+      },
+    });
+
+    render(<UserMessage content="Test message" />);
+
+    const avatar = screen.getByTestId("avatar");
+    expect(avatar).toHaveAttribute("data-name", "John Doe");
+  });
+
+  it("should pass user email to Avatar when session has email", () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          name: "John Doe",
+          email: "john@example.com",
+        },
+      },
+    });
+
+    render(<UserMessage content="Test message" />);
+
+    const avatar = screen.getByTestId("avatar");
+    expect(avatar).toHaveAttribute("data-email", "john@example.com");
+  });
+
+  it("should handle session with partial user data", () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          name: "John",
+        },
+      },
+    });
+
+    render(<UserMessage content="Test message" />);
+
+    const avatar = screen.getByTestId("avatar");
+    expect(avatar).toHaveAttribute("data-name", "John");
+    expect(avatar).toHaveAttribute("data-email", "");
+  });
+
+  it("should render long message content", () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          name: "Test User",
+          email: "test@example.com",
+        },
+      },
+    });
+
+    const longMessage =
+      "This is a very long message that should be displayed correctly in the component without breaking the layout or causing any issues with rendering.";
+
+    render(<UserMessage content={longMessage} />);
+
+    expect(screen.getByText(longMessage)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Added unit tests for all chat UI components
- Created test files for 17 chat components:
  - AIMessage, AIMessageContent, AIMessageHeader
  - AIResponseSkeleton, ChatHistoryList, ChatInitialView
  - ChatInput, ChatItem, ChatMessages, ChatMessagesSkeleton
  - DataTable, DatasetChangeWarning, DGIcon
  - LoadingSpinner, MessageItem, TemperatureMap, UserMessage
- Added beforeEach setup to improve test structure and reduce code duplication
- Tests cover component rendering, user interactions, props handling, and edge cases