### PR TITLE
DG-101|Recommended Datasets

### DIFF
--- a/src/components/DatasetDetailsPage/DatasetDetailsPageContent.module.scss
+++ b/src/components/DatasetDetailsPage/DatasetDetailsPageContent.module.scss
@@ -5,12 +5,12 @@
   background: $color-background;
 
   &__container {
-    max-width: $container-max-width;
+    max-width: 1440px;
     margin: 0 auto;
-    padding: $spacing-3xl 0;
+    padding: $spacing-3xl $spacing-xl;
 
     @media (max-width: $breakpoint-md - 1px) {
-      padding: $spacing-xl 0;
+      padding: $spacing-xl $spacing-lg;
     }
   }
 
@@ -75,7 +75,7 @@
   &__sectionTitle {
     @include text-2xl;
     @include text-primary;
-    margin-bottom: $spacing-2xl; // Add margin below title
+    margin-bottom: $spacing-2xl;
 
     @media (max-width: $breakpoint-md - 1px) {
       font-size: $font-size-xl;
@@ -85,9 +85,9 @@
 
   &__row {
     display: flex;
-    gap: $spacing-2xl; // 32px gap between columns
+    gap: $spacing-2xl;
     align-items: flex-start;
-    margin-bottom: $spacing-3xl; // Gap between rows
+    margin-bottom: $spacing-3xl;
 
     @media (max-width: $breakpoint-lg - 1px) {
       flex-direction: column;
@@ -99,15 +99,15 @@
     }
 
     &:last-child {
-      margin-bottom: 0; // Remove margin from last row
+      margin-bottom: 0;
     }
   }
 
   &__rowLeft {
     flex: 1;
     @include flex-column;
-    gap: 0; // No gap, title has margin-bottom
-    min-width: 0; // Allow flex item to shrink
+    gap: 0;
+    min-width: 0;
 
     @media (max-width: $breakpoint-lg - 1px) {
       width: 100%;

--- a/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
+++ b/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
@@ -11,6 +11,7 @@ import styles from "./DatasetDetailsPageContent.module.scss";
 import DatasetFilesTree from "./DatasetFilesTree/DatasetFilesTree";
 import DatasetHeader from "./DatasetHeader/DatasetHeader";
 import DatasetMetadataBar from "./DatasetMetadataBar/DatasetMetadataBar";
+import DatasetRecommendationsSection from "./DatasetRecommendationsSection/DatasetRecommendationsSection";
 import DatasetSidebar from "./DatasetSidebar/DatasetSidebar";
 import DatasetSpecificationSection from "./DatasetSpecificationSection/DatasetSpecificationSection";
 import DatasetTagsSection from "./DatasetTagsSection/DatasetTagsSection";
@@ -151,6 +152,8 @@ export default function DatasetDetailsPageContent({
               <DatasetFilesTree onFileSelect={handleFileSelect} />
             </div>
           </div>
+
+          <DatasetRecommendationsSection />
         </div>
       </div>
     </div>

--- a/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.module.scss
+++ b/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.module.scss
@@ -1,0 +1,132 @@
+@use '@/styles' as *;
+
+.datasetRecommendationsSection {
+  @include flex-column;
+  gap: $spacing-lg;
+  max-width: 1440px;
+  width: 100%;
+  margin: 0 auto;
+
+  &__title {
+    @include font-semibold;
+    font-size: $font-size-2xl;
+    @include text-primary;
+    line-height: $line-height-tight;
+    margin: 0;
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: $spacing-lg;
+    row-gap: 20px;
+
+    @media (max-width: $breakpoint-xl - 1px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media (max-width: $breakpoint-md - 1px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__card {
+    @include border-base;
+    @include border-radius-lg;
+    background: $color-background;
+    padding: 20px;
+    cursor: pointer;
+    @include transition-base;
+
+    &:hover {
+      @include shadow-s2;
+    }
+
+    &:focus {
+      outline: 2px solid $color-info;
+      outline-offset: 2px;
+    }
+  }
+
+  &__cardContent {
+    @include flex-column;
+    gap: $spacing-lg;
+  }
+
+  &__cardHeader {
+    @include flex-column;
+    gap: $spacing-xs;
+  }
+
+  &__cardTitle {
+    @include font-semibold;
+    font-size: $font-size-lg;
+    color: $color-primary;
+    line-height: $line-height-tight;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    margin: 0;
+  }
+
+  &__cardChips {
+    display: flex;
+    gap: $spacing-xs;
+    flex-wrap: wrap;
+  }
+
+  &__cardDescription {
+    @include font-base;
+    font-size: $font-size-base;
+    @include text-secondary;
+    line-height: $line-height-normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    margin: 0;
+  }
+
+  &__skeletonTitle {
+    height: 34px;
+    display: flex;
+    align-items: center;
+  }
+
+  &__skeletonCard {
+    cursor: default;
+    pointer-events: none;
+  }
+
+  &__skeletonBar {
+    background: $color-border;
+    border-radius: $border-radius-sm;
+    animation: pulse 1.5s ease-in-out infinite;
+    height: 100%;
+  }
+
+  &__skeletonChip {
+    height: 24px;
+    width: 80px;
+  }
+
+  &__skeletonDescription {
+    @include flex-column;
+    gap: $spacing-xs;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+

--- a/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.test.tsx
+++ b/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DatasetRecommendationsSection from "./DatasetRecommendationsSection";
+
+const mockPush = vi.fn();
+const mockUseRouter = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockUseRouter(),
+}));
+
+describe("DatasetRecommendationsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+    });
+  });
+
+  it("renders recommendations from mock data", async () => {
+    render(<DatasetRecommendationsSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("You may also like")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("ERA5 Land")).toBeInTheDocument();
+    expect(screen.getByText("Horizon Europe")).toBeInTheDocument();
+    expect(screen.getByText("Copernicus")).toBeInTheDocument();
+    expect(screen.getByText("EUREKA")).toBeInTheDocument();
+    expect(screen.getByText("Digital Europe")).toBeInTheDocument();
+    expect(
+      screen.getByText("Fifth Space Weather Services"),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates to dataset details on card click", async () => {
+    render(<DatasetRecommendationsSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("ERA5 Land")).toBeInTheDocument();
+    });
+
+    const card = screen
+      .getByText("ERA5 Land")
+      .closest("div[role='button']") as HTMLElement | null;
+    if (card) {
+      fireEvent.click(card);
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(
+          expect.stringContaining(`/datasets/recommendation-1`),
+        );
+      });
+    }
+  });
+
+  it("handles keyboard navigation", async () => {
+    render(<DatasetRecommendationsSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("ERA5 Land")).toBeInTheDocument();
+    });
+
+    const card = screen
+      .getByText("ERA5 Land")
+      .closest("div[role='button']") as HTMLElement | null;
+    if (card) {
+      fireEvent.keyDown(card, { key: "Enter" });
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalled();
+      });
+    }
+  });
+});

--- a/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { Chip } from "@ui/Chip";
+import FormattedText from "@ui/FormattedText";
+import { useRouter } from "next/navigation";
+import type { DatasetPlus } from "@/data/dataset";
+import { getNavigationUrl } from "@/lib/utils";
+import styles from "./DatasetRecommendationsSection.module.scss";
+
+const RECOMMENDATIONS_COUNT = 6;
+type MockRecommendation = DatasetPlus & { displayCategory: string };
+
+const mockRecommendations: MockRecommendation[] = [
+  {
+    id: "recommendation-1",
+    title: "ERA5 Land",
+    category: "Weather",
+    displayCategory: "Navigation",
+    access: "Open Access",
+    description:
+      "Galileo provides high-precision satellite navigation services, supporting various applications in transport, agriculture, and emergency response globally since its launch in 2016.",
+    size: "N/A",
+    lastUpdated: "2024-01-01",
+    tags: [],
+    collections: [],
+  },
+  {
+    id: "recommendation-2",
+    title: "Horizon Europe",
+    category: "Weather",
+    displayCategory: "Research",
+    access: "Open Access",
+    description:
+      "Horizon Europe is the EU's key funding program for research and innovation, aiming to enhance scientific excellence and tackle societal challenges, fostering collaboration across disciplines since 2021.",
+    size: "N/A",
+    lastUpdated: "2024-01-01",
+    tags: [],
+    collections: [],
+  },
+  {
+    id: "recommendation-3",
+    title: "Copernicus",
+    category: "Weather",
+    displayCategory: "Weather",
+    access: "Open Access",
+    description:
+      "The Copernicus program offers comprehensive data from its Sentinel satellites, enabling detailed monitoring of land, ocean, and atmosphere. It's crucial for climate change assessment and disaster management since 2014.",
+    size: "N/A",
+    lastUpdated: "2024-01-01",
+    tags: [],
+    collections: [],
+  },
+  {
+    id: "recommendation-4",
+    title: "EUREKA",
+    category: "Weather",
+    displayCategory: "Innovation",
+    access: "Open Access",
+    description:
+      "EUREKA is an intergovernmental network that supports market-oriented R&D, promoting innovation initiatives across Europe since 1985, enhancing competitiveness and economic growth.",
+    size: "N/A",
+    lastUpdated: "2024-01-01",
+    tags: [],
+    collections: [],
+  },
+  {
+    id: "recommendation-5",
+    title: "Digital Europe",
+    category: "Weather",
+    displayCategory: "Technology",
+    access: "Open Access",
+    description:
+      "Digital Europe is a funding program focused on accelerating digital transformation in Europe, aiming to equip the EU with advanced digital skills and infrastructure since 2021.",
+    size: "N/A",
+    lastUpdated: "2024-01-01",
+    tags: [],
+    collections: [],
+  },
+  {
+    id: "recommendation-6",
+    title: "Fifth Space Weather Services",
+    category: "Weather",
+    displayCategory: "Space Monitoring",
+    access: "Open Access",
+    description:
+      "The Fifth Space Weather Services program aims to enhance the prediction and monitoring of space weather phenomena to protect technological infrastructure and improve safety since 2022.",
+    size: "N/A",
+    lastUpdated: "2024-01-01",
+    tags: [],
+    collections: [],
+  },
+];
+
+export default function DatasetRecommendationsSection() {
+  const router = useRouter();
+
+  const handleCardClick = (dataset: DatasetPlus) => {
+    router.push(getNavigationUrl(`/datasets/${dataset.id}`));
+  };
+
+  const getDisplayCategory = (dataset: MockRecommendation): string =>
+    dataset.displayCategory || dataset.category;
+
+  return (
+    <div className={styles.datasetRecommendationsSection}>
+      <h3 className={styles.datasetRecommendationsSection__title}>
+        You may also like
+      </h3>
+      <div className={styles.datasetRecommendationsSection__grid}>
+        {mockRecommendations.slice(0, RECOMMENDATIONS_COUNT).map((dataset) => (
+          <div
+            key={dataset.id}
+            className={styles.datasetRecommendationsSection__card}
+            onClick={() => handleCardClick(dataset)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleCardClick(dataset);
+              }
+            }}
+            aria-label={`View details for ${dataset.title}`}
+          >
+            <div className={styles.datasetRecommendationsSection__cardContent}>
+              <div className={styles.datasetRecommendationsSection__cardHeader}>
+                <h4 className={styles.datasetRecommendationsSection__cardTitle}>
+                  {dataset.title}
+                </h4>
+                <div
+                  className={styles.datasetRecommendationsSection__cardChips}
+                >
+                  <Chip color="info" variant="outline" size="sm">
+                    {getDisplayCategory(dataset)}
+                  </Chip>
+                  <Chip
+                    color={
+                      dataset.access === "Open Access" ? "success" : "warning"
+                    }
+                    size="sm"
+                  >
+                    {dataset.access}
+                  </Chip>
+                </div>
+              </div>
+              <FormattedText
+                as="p"
+                className={
+                  styles.datasetRecommendationsSection__cardDescription
+                }
+                text={dataset.description || ""}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSkeleton.tsx
+++ b/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSkeleton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import styles from "./DatasetRecommendationsSection.module.scss";
+
+export default function DatasetRecommendationsSkeleton() {
+  return (
+    <div className={styles.datasetRecommendationsSection}>
+      <h3
+        className={`${styles.datasetRecommendationsSection__title} ${styles.datasetRecommendationsSection__skeletonTitle}`}
+      >
+        Recommended datasets
+      </h3>
+      <div className={styles.datasetRecommendationsSection__grid}>
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div
+            key={index}
+            className={`${styles.datasetRecommendationsSection__card} ${styles.datasetRecommendationsSection__skeletonCard}`}
+          >
+            <div className={styles.datasetRecommendationsSection__cardContent}>
+              <div className={styles.datasetRecommendationsSection__cardHeader}>
+                <div
+                  className={`${styles.datasetRecommendationsSection__cardTitle} ${styles.datasetRecommendationsSection__skeletonBar}`}
+                />
+                <div
+                  className={styles.datasetRecommendationsSection__cardChips}
+                >
+                  <div
+                    className={`${styles.datasetRecommendationsSection__skeletonChip} ${styles.datasetRecommendationsSection__skeletonBar}`}
+                  />
+                  <div
+                    className={`${styles.datasetRecommendationsSection__skeletonChip} ${styles.datasetRecommendationsSection__skeletonBar}`}
+                  />
+                </div>
+              </div>
+              <div
+                className={`${styles.datasetRecommendationsSection__cardDescription} ${styles.datasetRecommendationsSection__skeletonDescription}`}
+              >
+                <div
+                  className={styles.datasetRecommendationsSection__skeletonBar}
+                />
+                <div
+                  className={styles.datasetRecommendationsSection__skeletonBar}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Replaced API fetching with static mock data that matches the design 1:1  
- Restored the “You may also like” header  
- Added displayCategory field so chips match the design while keeping DatasetPlus types  
- Fixed test file to use vitest instead of jest  
- Updated tests to validate mock content and navigation  
- Removed invalid dataset.name usage in the recommendations component  
- Biome check on recommendation files passes cleanly