### PR TITLE
DG-102|User Profile

### DIFF
--- a/src/components/UserProfile/UserProfile.tsx
+++ b/src/components/UserProfile/UserProfile.tsx
@@ -2,6 +2,7 @@
 
 import PersonalSettingsSection from "@ui/user/PersonalSettingsSection";
 import PreferencesSection from "@ui/user/PreferencesSection";
+import RolesPermissionsSection from "@ui/user/RolesPermissionsSection";
 import TabsHeader from "@ui/user/TabsHeader";
 import { useEffect, useState } from "react";
 import { useUser } from "@/contexts/UserContext";
@@ -107,29 +108,6 @@ export default function UserProfile() {
     }
   }
 
-  const handleEnableAll = () => {
-    setNotifications((prev) => ({
-      ...prev,
-      newFeatures: { email: true, inApp: true },
-      datasetLibraryChanges: { email: true, inApp: true },
-      newDatasets: { email: true, inApp: true },
-      systemMaintenance: { email: true, inApp: true },
-      systemErrors: { email: true, inApp: true },
-    }));
-  };
-
-  // Simple comparisons don't need memoization - prefer readable code
-  const handleDisableAll = () => {
-    setNotifications((prev) => ({
-      ...prev,
-      newFeatures: { email: false, inApp: false },
-      datasetLibraryChanges: { email: false, inApp: false },
-      newDatasets: { email: false, inApp: false },
-      systemMaintenance: { email: false, inApp: false },
-      systemErrors: { email: false, inApp: false },
-    }));
-  };
-
   const updateNotification = (
     key: keyof NotificationSettings,
     type: "email" | "inApp",
@@ -169,13 +147,11 @@ export default function UserProfile() {
             <PreferencesSection
               isLoading={isLoading}
               notifications={notifications}
-              onEnableAll={handleEnableAll}
-              onDisableAll={handleDisableAll}
               updateNotification={updateNotification}
             />
           )}
 
-          {activeTab === "roles" && null}
+          {activeTab === "roles" && <RolesPermissionsSection />}
         </div>
       </div>
     </>

--- a/src/components/ui/user/DatasetPermissionsModal.tsx
+++ b/src/components/ui/user/DatasetPermissionsModal.tsx
@@ -1,0 +1,571 @@
+"use client";
+
+import { Button } from "@ui/Button";
+import { Input } from "@ui/Input";
+import { Search, Settings2, Trash2, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { ManageGroupsModal } from "./ManageGroupsModal";
+
+type PermissionKey =
+  | "browse"
+  | "delete"
+  | "download"
+  | "edit"
+  | "manage"
+  | "search";
+
+type GroupPermissionsRow = {
+  id: string;
+  name: string;
+  permissions: Record<PermissionKey, boolean>;
+};
+
+type InvitedUser = {
+  id: string;
+  name: string;
+  email: string;
+  permissions: Record<PermissionKey, boolean>;
+};
+
+const permissionColumns: Array<{ key: PermissionKey; label: string }> = [
+  { key: "browse", label: "Browse" },
+  { key: "delete", label: "Delete" },
+  { key: "download", label: "Download" },
+  { key: "edit", label: "Edit" },
+  { key: "manage", label: "Manage" },
+  { key: "search", label: "Search" },
+];
+
+const initialGroupPermissions: GroupPermissionsRow[] = [
+  {
+    id: "analytics",
+    name: "Analytics Team",
+    permissions: {
+      browse: false,
+      delete: true,
+      download: false,
+      edit: false,
+      manage: true,
+      search: false,
+    },
+  },
+  {
+    id: "engineering",
+    name: "Engineering Team",
+    permissions: {
+      browse: false,
+      delete: true,
+      download: false,
+      edit: false,
+      manage: true,
+      search: false,
+    },
+  },
+  {
+    id: "moderators",
+    name: "Moderators",
+    permissions: {
+      browse: false,
+      delete: true,
+      download: false,
+      edit: false,
+      manage: true,
+      search: false,
+    },
+  },
+  {
+    id: "finance",
+    name: "Finance Team",
+    permissions: {
+      browse: false,
+      delete: false,
+      download: true,
+      edit: true,
+      manage: true,
+      search: false,
+    },
+  },
+  {
+    id: "researchers",
+    name: "Researchers",
+    permissions: {
+      browse: false,
+      delete: true,
+      download: false,
+      edit: false,
+      manage: true,
+      search: false,
+    },
+  },
+  {
+    id: "finance-duplicate",
+    name: "Finance Team",
+    permissions: {
+      browse: false,
+      delete: false,
+      download: true,
+      edit: true,
+      manage: true,
+      search: false,
+    },
+  },
+];
+
+const initialInvitedUsers: InvitedUser[] = [
+  {
+    id: "naomi",
+    name: "Naomi Watts",
+    email: "naomi.watts@gmail.com",
+    permissions: {
+      browse: false,
+      delete: true,
+      download: false,
+      edit: false,
+      manage: true,
+      search: false,
+    },
+  },
+];
+
+interface DatasetPermissionsModalProps {
+  isOpen: boolean;
+  datasetName: string;
+  onClose: () => void;
+}
+
+function PermissionSwitch({
+  checked,
+  onChange,
+  ariaLabel,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={checked}
+      aria-label={ariaLabel}
+      onClick={onChange}
+      className={`flex items-center w-7 h-4 rounded-full p-[2px] transition-colors ${
+        checked ? "bg-[#052F4A] justify-end" : "bg-slate-200 justify-start"
+      }`}
+    >
+      <span className="bg-white w-3 h-3 rounded-full shadow-[0px_0.6px_0.6px_0px_rgba(213,218,227,0.3)]" />
+    </button>
+  );
+}
+
+export function DatasetPermissionsModal({
+  isOpen,
+  datasetName,
+  onClose,
+}: DatasetPermissionsModalProps) {
+  const [activeTab, setActiveTab] = useState<"groups" | "invite">("groups");
+  const [isManageOpen, setIsManageOpen] = useState(false);
+  const [groupSearch, setGroupSearch] = useState("");
+  const [inviteSearch, setInviteSearch] = useState("");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [groupPermissions, setGroupPermissions] = useState(
+    initialGroupPermissions,
+  );
+  const [invitedUsers, setInvitedUsers] = useState(initialInvitedUsers);
+  const [invitePermissions, setInvitePermissions] = useState<
+    Record<PermissionKey, boolean>
+  >({
+    browse: false,
+    delete: false,
+    download: false,
+    edit: false,
+    manage: false,
+    search: false,
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setActiveTab("groups");
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleEscape);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen, onClose]);
+
+  const filteredGroupRows = useMemo(() => {
+    const query = groupSearch.trim().toLowerCase();
+    if (!query) return groupPermissions;
+    return groupPermissions.filter((row) =>
+      row.name.toLowerCase().includes(query),
+    );
+  }, [groupPermissions, groupSearch]);
+
+  const filteredInvitedUsers = useMemo(() => {
+    const query = inviteSearch.trim().toLowerCase();
+    if (!query) return invitedUsers;
+    return invitedUsers.filter(
+      (user) =>
+        user.name.toLowerCase().includes(query) ||
+        user.email.toLowerCase().includes(query),
+    );
+  }, [inviteSearch, invitedUsers]);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 p-4"
+        onClick={(event) => {
+          if (event.target === event.currentTarget) {
+            onClose();
+          }
+        }}
+      >
+        <div
+          className="bg-white rounded-lg shadow-[0px_4px_10px_0px_rgba(29,41,61,0.1)] w-full max-w-[960px] h-[744px] max-h-[90vh] flex flex-col"
+          onClick={(event) => event.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-label={datasetName}
+        >
+          <div className="flex items-center h-[72px] px-6 pr-4 border-b border-slate-200">
+            <h2 className="text-[18px] font-semibold leading-[140%] text-slate-850 flex-1 truncate">
+              {datasetName}
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-10 h-10 flex items-center justify-center rounded"
+              aria-label="Close modal"
+            >
+              <X className="w-5 h-5 text-icon" strokeWidth={1.25} />
+            </button>
+          </div>
+
+          <div className="border-b border-slate-200 px-6">
+            <div className="flex gap-2 h-[55px]">
+              <button
+                type="button"
+                onClick={() => setActiveTab("groups")}
+                className="relative flex items-end h-full px-2"
+              >
+                <span
+                  className={`text-[16px] font-medium leading-[150%] ${
+                    activeTab === "groups" ? "text-gray-750" : "text-gray-650"
+                  }`}
+                >
+                  Groups
+                </span>
+                {activeTab === "groups" && (
+                  <span className="absolute bottom-0 left-0 right-0 h-[3px] bg-blue-500 rounded-t-[2px]" />
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab("invite")}
+                className="relative flex items-end h-full px-2"
+              >
+                <span
+                  className={`text-[16px] font-medium leading-[150%] ${
+                    activeTab === "invite" ? "text-gray-750" : "text-gray-650"
+                  }`}
+                >
+                  Invite by E-mail
+                </span>
+                {activeTab === "invite" && (
+                  <span className="absolute bottom-0 left-0 right-0 h-[3px] bg-blue-500 rounded-t-[2px]" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-6 pt-2">
+            {activeTab === "groups" && (
+              <div className="flex flex-col gap-6">
+                <div className="flex items-center gap-2">
+                  <Input
+                    name="group-search"
+                    placeholder="Search"
+                    value={groupSearch}
+                    onChange={(event) => setGroupSearch(event.target.value)}
+                    rightIcon={<Search className="w-4 h-4 text-icon" />}
+                    className="h-10"
+                  />
+                  <Button
+                    variant="outline"
+                    size="md"
+                    onClick={() => setIsManageOpen(true)}
+                    className="rounded-full gap-2"
+                  >
+                    <Settings2
+                      className="w-4 h-4 text-icon"
+                      strokeWidth={1.25}
+                    />
+                    Manage
+                  </Button>
+                </div>
+
+                <div>
+                  <div className="flex items-center h-12">
+                    <div className="flex-1 text-[16px] font-semibold leading-[150%] text-gray-750">
+                      Group permissions
+                    </div>
+                    <div className="flex gap-1 text-[14px] text-gray-750">
+                      {permissionColumns.map((column) => (
+                        <div key={column.key} className="w-20 text-center">
+                          {column.label}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="max-h-[401px] overflow-y-auto border-t border-b border-slate-200">
+                    {filteredGroupRows.map((row) => (
+                      <div
+                        key={row.id}
+                        className="flex items-center h-[72px] border-b border-slate-200 last:border-b-0"
+                      >
+                        <div className="flex-1 text-[14px] font-medium text-slate-850">
+                          {row.name}
+                        </div>
+                        <div className="flex gap-1">
+                          {permissionColumns.map((column) => (
+                            <div
+                              key={`${row.id}-${column.key}`}
+                              className="w-20 flex justify-center"
+                            >
+                              <PermissionSwitch
+                                checked={row.permissions[column.key]}
+                                ariaLabel={`${row.name} ${column.label}`}
+                                onChange={() =>
+                                  setGroupPermissions((prev) =>
+                                    prev.map((item) =>
+                                      item.id === row.id
+                                        ? {
+                                            ...item,
+                                            permissions: {
+                                              ...item.permissions,
+                                              [column.key]:
+                                                !item.permissions[column.key],
+                                            },
+                                          }
+                                        : item,
+                                    ),
+                                  )
+                                }
+                              />
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {activeTab === "invite" && (
+              <div className="flex flex-col gap-6">
+                <Input
+                  name="invite-search"
+                  placeholder="Search"
+                  value={inviteSearch}
+                  onChange={(event) => setInviteSearch(event.target.value)}
+                  rightIcon={<Search className="w-4 h-4 text-icon" />}
+                  className="h-10"
+                />
+
+                <div>
+                  <div className="flex items-center h-12">
+                    <div className="flex-1 text-[16px] font-semibold leading-[150%] text-gray-750">
+                      Invite new user
+                    </div>
+                    <div className="flex gap-1 text-[14px] text-gray-750">
+                      {permissionColumns.map((column) => (
+                        <div key={column.key} className="w-20 text-center">
+                          {column.label}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex items-center h-[72px] border-t border-b border-slate-200">
+                    <div className="flex-1 flex items-center gap-2">
+                      <Input
+                        name="invite-email"
+                        placeholder="Email address"
+                        value={inviteEmail}
+                        onChange={(event) => setInviteEmail(event.target.value)}
+                        className="h-10"
+                      />
+                      <Button
+                        variant="outline"
+                        size="md"
+                        onClick={() => {
+                          if (!inviteEmail.trim()) return;
+                          const email = inviteEmail.trim();
+                          setInvitedUsers((prev) => [
+                            ...prev,
+                            {
+                              id: `invite-${Date.now()}`,
+                              name: email.split("@")[0] || "Invited User",
+                              email,
+                              permissions: { ...invitePermissions },
+                            },
+                          ]);
+                          setInviteEmail("");
+                        }}
+                        className="rounded-full"
+                      >
+                        Invite
+                      </Button>
+                    </div>
+                    <div className="flex gap-1">
+                      {permissionColumns.map((column) => (
+                        <div
+                          key={column.key}
+                          className="w-20 flex justify-center"
+                        >
+                          <PermissionSwitch
+                            checked={invitePermissions[column.key]}
+                            ariaLabel={`Invite ${column.label}`}
+                            onChange={() =>
+                              setInvitePermissions((prev) => ({
+                                ...prev,
+                                [column.key]: !prev[column.key],
+                              }))
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <div className="flex items-center h-12">
+                    <div className="flex-1 text-[16px] font-semibold leading-[150%] text-gray-750">
+                      Users invited
+                    </div>
+                    <div className="flex gap-1 text-[14px] text-gray-750">
+                      {permissionColumns.map((column) => (
+                        <div key={column.key} className="w-20 text-center">
+                          {column.label}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="border-t border-b border-slate-200">
+                    {filteredInvitedUsers.map((user) => (
+                      <div
+                        key={user.id}
+                        className="flex items-center h-[72px] border-b border-slate-200 last:border-b-0"
+                      >
+                        <div className="flex-1 flex items-center gap-3">
+                          <div className="w-8 h-8 rounded-full bg-slate-200 overflow-hidden">
+                            <div className="w-full h-full flex items-center justify-center text-[12px] font-medium text-gray-750">
+                              {user.name
+                                .split(" ")
+                                .map((part) => part[0])
+                                .join("")
+                                .slice(0, 2)
+                                .toUpperCase()}
+                            </div>
+                          </div>
+                          <div className="flex flex-col">
+                            <span className="text-[14px] font-medium text-slate-850">
+                              {user.name}
+                            </span>
+                            <span className="text-[12px] text-gray-650 tracking-[0.12px]">
+                              {user.email}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex gap-1">
+                          {permissionColumns.map((column) => (
+                            <div
+                              key={`${user.id}-${column.key}`}
+                              className="w-20 flex justify-center"
+                            >
+                              <PermissionSwitch
+                                checked={user.permissions[column.key]}
+                                ariaLabel={`${user.name} ${column.label}`}
+                                onChange={() =>
+                                  setInvitedUsers((prev) =>
+                                    prev.map((item) =>
+                                      item.id === user.id
+                                        ? {
+                                            ...item,
+                                            permissions: {
+                                              ...item.permissions,
+                                              [column.key]:
+                                                !item.permissions[column.key],
+                                            },
+                                          }
+                                        : item,
+                                    ),
+                                  )
+                                }
+                              />
+                            </div>
+                          ))}
+                        </div>
+                        <button
+                          type="button"
+                          className="w-8 h-8 flex items-center justify-center rounded"
+                          aria-label={`Remove ${user.name}`}
+                          onClick={() =>
+                            setInvitedUsers((prev) =>
+                              prev.filter((item) => item.id !== user.id),
+                            )
+                          }
+                        >
+                          <Trash2
+                            className="w-4 h-4 text-icon"
+                            strokeWidth={1.25}
+                          />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="border-t border-slate-200 px-6 py-4 flex items-center justify-end gap-2">
+            <Button
+              variant="outline"
+              size="md"
+              onClick={onClose}
+              className="rounded-full w-[148px]"
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="md"
+              onClick={onClose}
+              className="rounded-full w-[148px]"
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <ManageGroupsModal
+        isOpen={isManageOpen}
+        onClose={() => setIsManageOpen(false)}
+        onSave={() => setIsManageOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/components/ui/user/ManageGroupsModal.tsx
+++ b/src/components/ui/user/ManageGroupsModal.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { Button } from "@ui/Button";
+import { Checkbox } from "@ui/Checkbox";
+import { Chip } from "@ui/Chip";
+import { Input } from "@ui/Input";
+import { Search, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+type GroupItem = {
+  id: string;
+  name: string;
+};
+
+const groups: GroupItem[] = [
+  { id: "administrators", name: "Administrators" },
+  { id: "analytics", name: "Analytics Team" },
+  { id: "engineering", name: "Engineering Team" },
+  { id: "finance", name: "Finance Team" },
+  { id: "moderators", name: "Moderators" },
+  { id: "mobile", name: "Mobile Team" },
+  { id: "researchers", name: "Researchers" },
+];
+
+interface ManageGroupsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+export function ManageGroupsModal({
+  isOpen,
+  onClose,
+  onSave,
+}: ManageGroupsModalProps) {
+  const [search, setSearch] = useState("");
+  const [selectedGroups, setSelectedGroups] = useState<string[]>([
+    "analytics",
+    "engineering",
+    "finance",
+    "moderators",
+    "researchers",
+  ]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleEscape);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen, onClose]);
+
+  const visibleGroups = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return groups;
+    return groups.filter((group) => group.name.toLowerCase().includes(query));
+  }, [search]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60 p-4"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="bg-white rounded-lg shadow-[0px_4px_10px_0px_rgba(29,41,61,0.1)] w-full max-w-[960px] h-[744px] max-h-[90vh] flex flex-col"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Manage Groups"
+      >
+        <div className="flex items-center h-[72px] px-6 pr-4 border-b border-slate-200">
+          <h2 className="text-[18px] font-semibold leading-[140%] text-slate-850 flex-1">
+            Manage Groups
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-10 h-10 flex items-center justify-center rounded"
+            aria-label="Close modal"
+          >
+            <X className="w-5 h-5 text-icon" strokeWidth={1.25} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 pt-6">
+          <div className="text-[16px] font-semibold leading-[150%] text-gray-750 mb-4">
+            Groups
+          </div>
+          <Input
+            name="manage-groups-search"
+            placeholder="Search..."
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            icon={<Search className="w-4 h-4 text-icon" strokeWidth={1.25} />}
+            className="h-10"
+          />
+
+          <div className="mt-4 border-t border-slate-200">
+            {visibleGroups.map((group) => {
+              const isSelected = selectedGroups.includes(group.id);
+              return (
+                <div
+                  key={group.id}
+                  className="flex items-center justify-between h-[72px] border-b border-slate-200"
+                >
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      id={`group-${group.id}`}
+                      checked={isSelected}
+                      onChange={(checked) => {
+                        setSelectedGroups((prev) =>
+                          checked
+                            ? [...prev, group.id]
+                            : prev.filter((id) => id !== group.id),
+                        );
+                      }}
+                    />
+                    <span className="text-[14px] font-medium text-slate-850">
+                      {group.name}
+                    </span>
+                  </div>
+                  {isSelected && (
+                    <Chip
+                      variant="regular"
+                      color="info"
+                      size="xs"
+                      className="bg-blue-50 border-blue-50 text-blue-800"
+                    >
+                      Added
+                    </Chip>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="border-t border-slate-200 px-6 py-4 flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="md"
+            onClick={onClose}
+            className="rounded-full w-[148px]"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={onSave}
+            className="rounded-full w-[148px]"
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/user/PersonalSettingsSection.tsx
+++ b/src/components/ui/user/PersonalSettingsSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@ui/Button";
-import { Input } from "@ui/Input";
 import { Trash } from "lucide-react";
 
 type FormData = {
@@ -9,65 +8,115 @@ type FormData = {
   surname: string;
 };
 
+type UserData = {
+  name: string;
+  surname: string;
+  email: string;
+  profilePicture?: string | null;
+};
+
 interface Props {
   formData: FormData;
-  updateFormData: (data: Partial<FormData>) => void;
-  isLoading: boolean;
+  userData: UserData;
 }
 
-export default function PersonalSettingsSection({
-  formData,
-  updateFormData,
-  isLoading,
-}: Props) {
+export default function PersonalSettingsSection({ formData, userData }: Props) {
+  const fullName = `${formData.name} ${formData.surname}`.trim();
+  const initials =
+    `${formData.name?.[0] || ""}${formData.surname?.[0] || ""}`.toUpperCase();
+
   return (
-    <div className="space-y-8">
-      <div className="flex flex-col gap-1 items-start justify-start border-b border-slate-200 pb-4">
-        <h2 className="text-H2-20-semibold text-gray-750">Personal Settings</h2>
-        <p className="text-body-14-regular text-gray-650">
-          Manage your account information and security settings
-        </p>
+    <div className="flex flex-col w-full gap-4">
+      <div className="flex items-center h-12 mb-2">
+        <h2 className="text-[16px] font-semibold leading-[150%] text-gray-750">
+          Basic Info
+        </h2>
       </div>
-      <div className="space-y-8">
-        <div>
-          <h3 className="text-body-16-medium text-gray-750 mb-4">
-            Basic information
-          </h3>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <Input
-              name="name"
-              label="Name"
-              size="large"
-              value={formData.name}
-              onChange={(e) => updateFormData({ name: e.target.value })}
-              disabled={true}
-            />
-            <Input
-              name="surname"
-              label="Surname"
-              size="large"
-              value={formData.surname}
-              onChange={(e) => updateFormData({ surname: e.target.value })}
-              disabled={true}
-            />
+
+      <div className="flex flex-col gap-4 py-6 border-y border-slate-200 lg:flex-row lg:items-center lg:gap-8">
+        <div className="w-full lg:w-[300px]">
+          <div className="text-[14px] font-medium leading-[150%] text-gray-750">
+            User Info
+          </div>
+          <div className="text-[12px] leading-[150%] text-gray-650 tracking-[0.12px]">
+            Your account information
           </div>
         </div>
-
-        <div className="pt-8 border-t border-slate-200">
-          <h3 className="text-body-16-medium text-gray-750 mb-2">
-            Delete Account
-          </h3>
-          <p className="text-body-14-regular text-gray-650 mb-4">
-            Permanently delete your account and all associated data
-          </p>
-          <Button
-            variant="primary"
-            className="bg-red-600 border-red-600 hover:bg-red-400 hover:border-red-400"
-          >
-            <Trash strokeWidth={1.25} className="w-4 h-4 mr-2" />
-            Delete Account
-          </Button>
+        <div className="flex items-center gap-4">
+          <div className="w-10 h-10 rounded-full overflow-hidden bg-slate-200">
+            {userData.profilePicture ? (
+              <img
+                src={userData.profilePicture}
+                alt={fullName || "User"}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-[12px] font-medium text-gray-650">
+                {initials}
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <div className="text-[16px] font-semibold leading-[150%] text-gray-750">
+                {fullName || "User"}
+              </div>
+              <div className="h-6 px-3 rounded-full bg-emerald-50 text-emerald-800 text-[12px] font-medium leading-[150%] tracking-[0.12px] flex items-center">
+                User
+              </div>
+            </div>
+            <div className="text-[12px] leading-[150%] text-gray-650 tracking-[0.12px]">
+              {userData.email}
+            </div>
+          </div>
         </div>
+      </div>
+
+      <div className="flex flex-col gap-4 py-6 border-y border-slate-200 -mt-px lg:flex-row lg:items-center lg:gap-8">
+        <div className="w-full lg:w-[300px]">
+          <div className="text-[14px] font-medium leading-[150%] text-gray-750">
+            Account name
+          </div>
+          <div className="text-[12px] leading-[150%] text-gray-650 tracking-[0.12px]">
+            Your account information
+          </div>
+        </div>
+        <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
+          <div className="flex-1 min-w-0">
+            <div className="text-[14px] font-medium leading-[150%] text-gray-650">
+              Name
+            </div>
+            <div className="mt-1 h-10 px-3 rounded-full border border-slate-200 bg-slate-50 flex items-center text-[14px] text-slate-450">
+              {formData.name}
+            </div>
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-[14px] font-medium leading-[150%] text-gray-650">
+              Surname
+            </div>
+            <div className="mt-1 h-10 px-3 rounded-full border border-slate-200 bg-slate-50 flex items-center text-[14px] text-slate-450">
+              {formData.surname}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4 py-6 border-y border-slate-200 -mt-px lg:flex-row lg:items-center lg:gap-8">
+        <div className="w-full lg:w-[300px]">
+          <div className="text-[14px] font-medium leading-[150%] text-gray-750">
+            Delete Account
+          </div>
+          <div className="text-[12px] leading-[150%] text-gray-650 tracking-[0.12px]">
+            Permanently delete your account and all associated data
+          </div>
+        </div>
+        <Button
+          variant="primary"
+          className="h-10 px-4 bg-red-600 border-red-600 hover:bg-red-600 hover:border-red-600 shadow-s1 w-full sm:w-auto"
+        >
+          <Trash strokeWidth={1.25} className="w-4 h-4 mr-2" />
+          Delete Account
+        </Button>
       </div>
     </div>
   );

--- a/src/components/ui/user/PreferencesSection.test.tsx
+++ b/src/components/ui/user/PreferencesSection.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PreferencesSection from "./PreferencesSection";
+
+const baseNotifications = {
+  newFeatures: { email: false, inApp: false },
+  datasetLibraryChanges: { email: false, inApp: false },
+  newDatasets: { email: false, inApp: false },
+  systemMaintenance: { email: false, inApp: false },
+  systemErrors: { email: false, inApp: false },
+};
+
+describe("PreferencesSection", () => {
+  it("renders header and rows", () => {
+    render(
+      <PreferencesSection
+        notifications={baseNotifications}
+        updateNotification={vi.fn()}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText("Group permissions")).toBeInTheDocument();
+    expect(screen.getByText("New Features")).toBeInTheDocument();
+    expect(screen.getByText("Dataset Library Changes")).toBeInTheDocument();
+  });
+
+  it("toggles email switch", () => {
+    const updateNotification = vi.fn();
+    render(
+      <PreferencesSection
+        notifications={baseNotifications}
+        updateNotification={updateNotification}
+        isLoading={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("New Features email"));
+
+    expect(updateNotification).toHaveBeenCalledWith(
+      "newFeatures",
+      "email",
+      true,
+    );
+  });
+});

--- a/src/components/ui/user/PreferencesSection.test.tsx
+++ b/src/components/ui/user/PreferencesSection.test.tsx
@@ -15,6 +15,13 @@ describe("PreferencesSection", () => {
     render(
       <PreferencesSection
         notifications={baseNotifications}
+        onEnableAll={vi.fn()}
+        onDisableAll={vi.fn()}
+        onReset={vi.fn()}
+        onDeleteSaved={vi.fn()}
+        onSave={vi.fn()}
+        hasSavedSettings={false}
+        hasChanges={false}
         updateNotification={vi.fn()}
         isLoading={false}
       />,
@@ -30,6 +37,13 @@ describe("PreferencesSection", () => {
     render(
       <PreferencesSection
         notifications={baseNotifications}
+        onEnableAll={vi.fn()}
+        onDisableAll={vi.fn()}
+        onReset={vi.fn()}
+        onDeleteSaved={vi.fn()}
+        onSave={vi.fn()}
+        hasSavedSettings={false}
+        hasChanges={true}
         updateNotification={updateNotification}
         isLoading={false}
       />,

--- a/src/components/ui/user/PreferencesSection.tsx
+++ b/src/components/ui/user/PreferencesSection.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Button } from "@ui/Button";
+
 type NotificationSettings = {
   newFeatures: { email: boolean; inApp: boolean };
   datasetLibraryChanges: { email: boolean; inApp: boolean };
@@ -17,6 +19,13 @@ type NotificationCategory =
 
 interface Props {
   notifications: NotificationSettings;
+  onEnableAll: () => void;
+  onDisableAll: () => void;
+  onReset: () => void;
+  onDeleteSaved: () => void;
+  onSave: () => void;
+  hasSavedSettings: boolean;
+  hasChanges: boolean;
   updateNotification: (
     category: NotificationCategory,
     type: "email" | "inApp",
@@ -60,6 +69,13 @@ const NOTIFICATION_ITEMS: Array<{
 
 export default function PreferencesSection({
   notifications,
+  onEnableAll,
+  onDisableAll,
+  onReset,
+  onDeleteSaved,
+  onSave,
+  hasSavedSettings,
+  hasChanges,
   updateNotification,
   isLoading,
 }: Props) {
@@ -84,6 +100,48 @@ export default function PreferencesSection({
 
   return (
     <div className="bg-white rounded-2xl">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 border-b border-slate-200 pb-4">
+        <div className="flex flex-col gap-1 items-start justify-start">
+          <h2 className="text-[16px] font-semibold leading-[150%] text-gray-750">
+            Notification Preferences
+          </h2>
+          <p className="text-[12px] leading-[150%] text-gray-650 tracking-[0.12px]">
+            Choose how you want to be notified about updates and changes
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 self-end sm:self-auto sm:ml-auto">
+          <Button variant="outline" size="sm" onClick={onEnableAll}>
+            Enable All
+          </Button>
+          <Button variant="outline" size="sm" onClick={onDisableAll}>
+            Disable All
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onDeleteSaved}
+            disabled={isLoading || !hasSavedSettings}
+          >
+            Delete saved settings
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onReset}
+            disabled={isLoading}
+          >
+            Reset to defaults
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onSave}
+            disabled={isLoading || !hasChanges}
+          >
+            Save changes
+          </Button>
+        </div>
+      </div>
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:h-12 border-b border-slate-200 py-2 sm:py-0">
         <div className="flex-1 text-[16px] font-semibold leading-[150%] text-gray-750">
           Group permissions

--- a/src/components/ui/user/PreferencesSection.tsx
+++ b/src/components/ui/user/PreferencesSection.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { Button } from "@ui/Button";
-import { Checkbox } from "@ui/Checkbox";
-
 type NotificationSettings = {
   newFeatures: { email: boolean; inApp: boolean };
   datasetLibraryChanges: { email: boolean; inApp: boolean };
@@ -20,8 +17,6 @@ type NotificationCategory =
 
 interface Props {
   notifications: NotificationSettings;
-  onEnableAll: () => void;
-  onDisableAll: () => void;
   updateNotification: (
     category: NotificationCategory,
     type: "email" | "inApp",
@@ -65,73 +60,86 @@ const NOTIFICATION_ITEMS: Array<{
 
 export default function PreferencesSection({
   notifications,
-  onEnableAll,
-  onDisableAll,
   updateNotification,
   isLoading,
 }: Props) {
-  return (
-    <div className="space-y-8">
-      <div>
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 border-b border-slate-200 pb-6 sm:pb-8">
-          <div className="flex flex-col gap-1 items-start justify-start">
-            <h2 className="text-H2-20-semibold text-gray-750">
-              Notification Preferences
-            </h2>
-            <p className="text-body-14-regular text-gray-650">
-              Choose how you want to be notified about updates and changes
-            </p>
-          </div>
-          <div className="flex gap-2 self-end sm:self-auto sm:ml-auto">
-            <Button variant="outline" size="sm" onClick={onEnableAll}>
-              Enable All
-            </Button>
-            <Button variant="outline" size="sm" onClick={onDisableAll}>
-              Disable All
-            </Button>
-          </div>
-        </div>
+  const renderSwitch = (
+    isOn: boolean,
+    onToggle: () => void,
+    ariaLabel: string,
+  ) => (
+    <button
+      type="button"
+      aria-pressed={isOn}
+      aria-label={ariaLabel}
+      disabled={isLoading}
+      onClick={onToggle}
+      className={`flex items-center w-7 h-4 rounded-full p-[2px] transition-colors ${
+        isOn ? "bg-[#052F4A] justify-end" : "bg-slate-200 justify-start"
+      } ${isLoading ? "opacity-60 cursor-not-allowed" : "cursor-pointer"}`}
+    >
+      <span className="bg-white w-3 h-3 rounded-full shadow-[0px_0.6px_0.6px_0px_rgba(213,218,227,0.3)]" />
+    </button>
+  );
 
-        <div>
-          {NOTIFICATION_ITEMS.map((item, index, arr) => (
-            <div
-              key={item.key}
-              className={`grid grid-cols-1 sm:grid-cols-[38%_31%_31%] gap-4 items-start sm:items-center justify-items-start sm:justify-items-center py-6 sm:py-8 ${index < arr.length - 1 ? "border-b border-slate-200" : "pb-0"}`}
-            >
-              <div className="space-y-1 justify-self-start text-left">
-                <h3 className="text-body-16-medium text-gray-750">
-                  {item.title}
-                </h3>
-                <p className="text-descriptions-12-regular text-gray-650">
-                  {item.description}
-                </p>
-              </div>
-              <div className="justify-self-start sm:justify-self-center">
-                <Checkbox
-                  disabled={isLoading}
-                  id={`${item.key}-email`}
-                  label="E-mail"
-                  checked={notifications[item.key].email}
-                  onChange={(checked) =>
-                    updateNotification(item.key, "email", checked)
-                  }
-                />
-              </div>
-              <div className="justify-self-start sm:justify-self-center">
-                <Checkbox
-                  disabled={isLoading}
-                  id={`${item.key}-app`}
-                  label="In App"
-                  checked={notifications[item.key].inApp}
-                  onChange={(checked) =>
-                    updateNotification(item.key, "inApp", checked)
-                  }
-                />
-              </div>
-            </div>
-          ))}
+  return (
+    <div className="bg-white rounded-2xl">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:h-12 border-b border-slate-200 py-2 sm:py-0">
+        <div className="flex-1 text-[16px] font-semibold leading-[150%] text-gray-750">
+          Group permissions
+        </div>
+        <div className="hidden sm:flex w-40 text-[14px] font-normal leading-[150%] text-gray-750 text-center justify-center">
+          E-mail
+        </div>
+        <div className="hidden sm:flex w-40 text-[14px] font-normal leading-[150%] text-gray-750 text-center justify-center">
+          In App
         </div>
       </div>
+      {NOTIFICATION_ITEMS.map((item, index) => (
+        <div
+          key={item.key}
+          className={`flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:h-[72px] ${
+            index < NOTIFICATION_ITEMS.length - 1
+              ? "border-b border-slate-200"
+              : ""
+          }`}
+        >
+          <div className="flex-1">
+            <div className="text-[14px] font-medium leading-[150%] text-gray-750">
+              {item.title}
+            </div>
+            <div className="text-[12px] leading-[150%] text-gray-650 tracking-[0.12px]">
+              {item.description}
+            </div>
+          </div>
+          <div className="w-full sm:w-40 flex items-center gap-3 sm:justify-center">
+            <span className="text-[14px] text-gray-750 sm:hidden">E-mail</span>
+            {renderSwitch(
+              notifications[item.key].email,
+              () =>
+                updateNotification(
+                  item.key,
+                  "email",
+                  !notifications[item.key].email,
+                ),
+              `${item.title} email`,
+            )}
+          </div>
+          <div className="w-full sm:w-40 flex items-center gap-3 sm:justify-center">
+            <span className="text-[14px] text-gray-750 sm:hidden">In App</span>
+            {renderSwitch(
+              notifications[item.key].inApp,
+              () =>
+                updateNotification(
+                  item.key,
+                  "inApp",
+                  !notifications[item.key].inApp,
+                ),
+              `${item.title} in app`,
+            )}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/ui/user/RolesPermissionsSection.test.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import RolesPermissionsSection from "./RolesPermissionsSection";
+
+describe("RolesPermissionsSection", () => {
+  it("renders headers and table rows", () => {
+    render(<RolesPermissionsSection />);
+
+    expect(screen.getByText("User Access")).toBeInTheDocument();
+    expect(screen.getByText("Filters")).toBeInTheDocument();
+    expect(screen.getByText("Dataset name")).toBeInTheDocument();
+    expect(
+      screen.getByText("Hurricane Evacuation Data (2005-2023)"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/user/RolesPermissionsSection.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { Chip } from "@ui/Chip";
+import { Input } from "@ui/Input";
+import { ChevronDown, Pencil, Search, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { DatasetPermissionsModal } from "./DatasetPermissionsModal";
+
+type AccessRow = {
+  id: string;
+  datasetName: string;
+  groupsAdded: string;
+  uploadedBy: string;
+  permissions: string[];
+  actions: Array<"edit" | "delete">;
+};
+
+const accessRows: AccessRow[] = [
+  {
+    id: "row-1",
+    datasetName: "Hurricane Evacuation Data (2005-2023)",
+    groupsAdded: "3",
+    uploadedBy: "Beverly Griffin",
+    permissions: ["Edit", "+3"],
+    actions: ["edit", "delete"],
+  },
+  {
+    id: "row-2",
+    datasetName: "Global Surface Air Temperature (1980-2024)",
+    groupsAdded: "5",
+    uploadedBy: "Jeffery Woods",
+    permissions: ["Edit", "+3"],
+    actions: [],
+  },
+  {
+    id: "row-3",
+    datasetName: "Regional Precipitation Patterns (2010-2024)",
+    groupsAdded: "1",
+    uploadedBy: "Terry Obrien",
+    permissions: ["Edit", "+3"],
+    actions: [],
+  },
+  {
+    id: "row-4",
+    datasetName: "Coastal Sea Level Rise Projections (2025-2050)",
+    groupsAdded: "9",
+    uploadedBy: "Ricardo Barnes",
+    permissions: ["Edit", "+3"],
+    actions: ["edit", "delete"],
+  },
+  {
+    id: "row-5",
+    datasetName: "Extreme Weather Events Tracker (2018-2024)",
+    groupsAdded: "8",
+    uploadedBy: "Evelyn Hayes",
+    permissions: ["Edit", "+3"],
+    actions: ["edit", "delete"],
+  },
+];
+
+type DropdownOption = {
+  label: string;
+  value: string;
+};
+
+const showPermissionsOptions: DropdownOption[] = [{ label: "Me", value: "me" }];
+
+const typeOptions: DropdownOption[] = [
+  { label: "Datasets", value: "datasets" },
+];
+
+const permissionOptions: DropdownOption[] = [
+  { label: "Select", value: "all" },
+  { label: "Edit", value: "edit" },
+];
+
+const groupOptions: DropdownOption[] = [{ label: "All groups", value: "all" }];
+
+function DropdownField({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: DropdownOption[];
+  onChange: (value: string) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const selected = options.find((option) => option.value === value);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="relative w-full" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex flex-col gap-1 w-full text-left"
+        aria-expanded={isOpen}
+      >
+        <span className="text-[14px] font-medium leading-[150%] text-gray-750">
+          {label}
+        </span>
+        <span className="flex items-center gap-2 h-10 px-3 rounded-full border border-slate-300 shadow-s1 bg-white text-[14px] text-gray-750">
+          <span className="flex-1 truncate">{selected?.label ?? ""}</span>
+          <ChevronDown
+            className={`w-4 h-4 text-icon transition-transform ${
+              isOpen ? "rotate-180" : ""
+            }`}
+            strokeWidth={1.25}
+          />
+        </span>
+      </button>
+      {isOpen && (
+        <div className="absolute z-20 mt-2 w-full rounded-lg border border-slate-200 bg-white shadow-lg">
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              className="w-full px-3 py-2 text-left text-[14px] text-gray-750 hover:bg-slate-50"
+              onClick={() => {
+                onChange(option.value);
+                setIsOpen(false);
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SearchField({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1 w-full text-left">
+      <span className="text-[14px] font-medium leading-[150%] text-transparent select-none">
+        Search
+      </span>
+      <Input
+        name="roles-search"
+        placeholder="Search..."
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        rightIcon={<Search className="w-4 h-4 text-icon" strokeWidth={1.25} />}
+        className="h-10"
+      />
+    </div>
+  );
+}
+
+export default function RolesPermissionsSection() {
+  const [activeDataset, setActiveDataset] = useState<AccessRow | null>(null);
+  const [isPermissionsOpen, setIsPermissionsOpen] = useState(false);
+  const [showPermissionsFor, setShowPermissionsFor] = useState("me");
+  const [typeFilter, setTypeFilter] = useState("datasets");
+  const [permissionsFilter, setPermissionsFilter] = useState("all");
+  const [groupFilter, setGroupFilter] = useState("all");
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredRows = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    return accessRows.filter((row) => {
+      const matchesSearch =
+        !query || row.datasetName.toLowerCase().includes(query);
+      const matchesPermission =
+        permissionsFilter === "all" ||
+        row.permissions.some(
+          (permission) =>
+            permission.toLowerCase() === permissionsFilter.toLowerCase(),
+        );
+      return matchesSearch && matchesPermission;
+    });
+  }, [permissionsFilter, searchQuery]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center h-12 border-b border-slate-200">
+          <h2 className="text-[16px] font-semibold leading-[150%] text-gray-750">
+            User Access
+          </h2>
+        </div>
+        <div className="w-[294px]">
+          <DropdownField
+            label="Show permissions for"
+            value={showPermissionsFor}
+            options={showPermissionsOptions}
+            onChange={setShowPermissionsFor}
+          />
+        </div>
+        <div className="flex items-center h-12 border-b border-slate-200">
+          <h2 className="text-[16px] font-semibold leading-[150%] text-gray-750">
+            Filters
+          </h2>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-2 items-end">
+            <DropdownField
+              label="Type"
+              value={typeFilter}
+              options={typeOptions}
+              onChange={setTypeFilter}
+            />
+            <DropdownField
+              label="Permissions"
+              value={permissionsFilter}
+              options={permissionOptions}
+              onChange={setPermissionsFilter}
+            />
+            <DropdownField
+              label="Group"
+              value={groupFilter}
+              options={groupOptions}
+              onChange={setGroupFilter}
+            />
+            <SearchField value={searchQuery} onChange={setSearchQuery} />
+          </div>
+          <div className="text-[14px] leading-[150%] text-gray-750">
+            <span className="text-gray-650">Showing:</span>{" "}
+            {filteredRows.length} results
+          </div>
+        </div>
+
+        <div className="border border-slate-200 rounded-lg overflow-hidden">
+          <div className="min-w-[720px] overflow-x-auto">
+            <div className="grid grid-cols-[1fr_126px_180px_122px_137px] bg-slate-50 text-[14px] text-gray-650 border-b border-slate-200">
+              <div className="px-4 py-2 font-medium">Dataset name</div>
+              <div className="px-4 py-2 font-medium text-center">
+                Groups Added
+              </div>
+              <div className="px-4 py-2 font-medium">Uploaded by</div>
+              <div className="px-4 py-2 font-medium">Permissions</div>
+              <div className="px-4 py-2 font-medium">Dataset Actions</div>
+            </div>
+            {filteredRows.map((row) => (
+              <div
+                key={row.id}
+                className="grid grid-cols-[1fr_126px_180px_122px_137px] items-center h-14 border-b border-slate-200 last:border-b-0"
+              >
+                <div className="px-4 text-[14px] text-gray-750 truncate">
+                  {row.datasetName}
+                </div>
+                <div className="px-4 flex justify-center">
+                  <Chip color="info" variant="outline" size="sm">
+                    {row.groupsAdded}
+                  </Chip>
+                </div>
+                <div className="px-4 text-[14px] text-gray-750">
+                  {row.uploadedBy}
+                </div>
+                <div className="px-4 flex gap-2">
+                  {row.permissions.map((permission) => (
+                    <Chip
+                      key={`${row.id}-${permission}`}
+                      color="info"
+                      variant="outline"
+                      size="sm"
+                    >
+                      {permission}
+                    </Chip>
+                  ))}
+                </div>
+                <div className="px-4 flex justify-end gap-2">
+                  {row.actions.includes("edit") && (
+                    <button
+                      type="button"
+                      className="w-8 h-8 flex items-center justify-center rounded"
+                      aria-label={`Edit ${row.datasetName}`}
+                      onClick={() => {
+                        setActiveDataset(row);
+                        setIsPermissionsOpen(true);
+                      }}
+                    >
+                      <Pencil
+                        className="w-4 h-4 text-icon"
+                        strokeWidth={1.25}
+                      />
+                    </button>
+                  )}
+                  {row.actions.includes("delete") && (
+                    <button
+                      type="button"
+                      className="w-8 h-8 flex items-center justify-center rounded"
+                      aria-label={`Delete ${row.datasetName}`}
+                      onClick={() => {
+                        setActiveDataset(row);
+                        setIsPermissionsOpen(true);
+                      }}
+                    >
+                      <Trash2
+                        className="w-4 h-4 text-icon"
+                        strokeWidth={1.25}
+                      />
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      {activeDataset && (
+        <DatasetPermissionsModal
+          isOpen={isPermissionsOpen}
+          datasetName={activeDataset.datasetName}
+          onClose={() => setIsPermissionsOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/user/TabsHeader.tsx
+++ b/src/components/ui/user/TabsHeader.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Bell, type LucideIcon, UserRoundPen } from "lucide-react";
+import { Bell, FolderLock, type LucideIcon, UserRoundPen } from "lucide-react";
 
-type ActiveTab = "personal" | "preferences";
+type ActiveTab = "personal" | "notifications" | "roles";
 
 interface Props {
   activeTab: ActiveTab;
@@ -13,7 +13,6 @@ type TabItem = {
   key: ActiveTab;
   icon: LucideIcon;
   title: string;
-  description: string;
 };
 
 const TABS: TabItem[] = [
@@ -21,58 +20,48 @@ const TABS: TabItem[] = [
     key: "personal",
     icon: UserRoundPen,
     title: "Personal settings",
-    description: "Account information and security",
   },
   {
-    key: "preferences",
+    key: "notifications",
     icon: Bell,
-    title: "Preferences",
-    description: "Notifications and app settings",
+    title: "Notifications",
+  },
+  {
+    key: "roles",
+    icon: FolderLock,
+    title: "Roles & Permissions",
   },
 ];
 
 export default function TabsHeader({ activeTab, setActiveTab }: Props) {
   return (
-    <div className="bg-white rounded-2xl border border-slate-200 p-2 sm:pr-4 sm:py-4 sm:pl-0">
-      <nav className="flex sm:flex-col gap-2 sm:gap-4 overflow-x-auto sm:overflow-visible">
-        {TABS.map(({ key, icon: Icon, title, description }) => {
+    <div className="w-full border-b border-slate-200">
+      <nav className="flex gap-4 overflow-x-auto">
+        {TABS.map(({ key, icon: Icon, title }) => {
           const isActive = activeTab === key;
           return (
-            <div
+            <button
               key={key}
-              className="flex items-stretch sm:items-center gap-2 sm:gap-4 min-w-[260px] sm:min-w-0"
+              onClick={() => setActiveTab(key)}
+              className="relative flex items-center gap-2 h-[55px] px-2 pb-[14px] whitespace-nowrap"
             >
-              <div className="flex items-center justify-center">
-                <div
-                  className={`bg-blue-500 w-1 h-[48px] rounded-r-[4px] hidden sm:block ${
-                    isActive ? "bg-blue-600" : "bg-white"
-                  }`}
-                />
-              </div>
-              <button
-                onClick={() => setActiveTab(key)}
-                className={`flex-1 flex items-start gap-3 sm:gap-4 px-3 py-2.25 rounded-lg transition-colors text-left cursor-pointer ${
-                  isActive ? "bg-blue-75" : "hover:bg-slate-75"
+              <Icon
+                className={`w-[25px] h-[25px] ${
+                  isActive ? "text-blue-500" : "text-icon"
+                }`}
+                strokeWidth={1.25}
+              />
+              <span
+                className={`text-[18px] font-medium leading-[140%] ${
+                  isActive ? "text-gray-750" : "text-gray-650"
                 }`}
               >
-                <div className="flex items-center gap-3 flex-1">
-                  <Icon
-                    className={`w-5 h-5 mt-0.5 ${
-                      isActive ? "text-blue-850" : "text-icon"
-                    }`}
-                    strokeWidth={1.25}
-                  />
-                  <div className="flex flex-col">
-                    <span className="text-[14px] sm:text-[18px] font-semibold leading-[150%] sm:leading-[140%] text-gray-750">
-                      {title}
-                    </span>
-                    <span className="text-[12px] 3xl:text-[14px] font-normal leading-[150%] text-slate-450">
-                      {description}
-                    </span>
-                  </div>
-                </div>
-              </button>
-            </div>
+                {title}
+              </span>
+              {isActive && (
+                <span className="absolute bottom-0 left-0 right-0 h-[3px] bg-blue-500 rounded-t-[2px]" />
+              )}
+            </button>
           );
         })}
       </nav>

--- a/src/lib/apiErrors.ts
+++ b/src/lib/apiErrors.ts
@@ -20,6 +20,7 @@ export enum ApiErrorMessage {
   FETCH_LICENSES_FAILED = "Failed to fetch licenses",
   FETCH_USER_SETTINGS_FAILED = "Failed to fetch user settings",
   SAVE_USER_SETTINGS_FAILED = "Failed to save user settings",
+  DELETE_USER_SETTINGS_FAILED = "Failed to delete user settings",
   FETCH_GRANTS_FAILED = "Failed to fetch grants",
   FETCH_RECOMMENDATIONS_FAILED = "Failed to fetch recommendations",
   UNEXPECTED_ERROR = "An unexpected error occurred",

--- a/src/services/notificationSettingsService.ts
+++ b/src/services/notificationSettingsService.ts
@@ -1,0 +1,103 @@
+import type { useApi } from "@/hooks/useApi";
+import { logError } from "@/lib/logger";
+import type { UserSettings, UserSettingsPersist } from "@/types/userSettings";
+
+export const NOTIFICATION_SETTINGS_KEY = "notificationSettings";
+
+export type NotificationSettingsValue = {
+  newFeatures: { email: boolean; inApp: boolean };
+  datasetLibraryChanges: { email: boolean; inApp: boolean };
+  newDatasets: { email: boolean; inApp: boolean };
+  systemMaintenance: { email: boolean; inApp: boolean };
+  systemErrors: { email: boolean; inApp: boolean };
+};
+
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettingsValue = {
+  newFeatures: { email: false, inApp: false },
+  datasetLibraryChanges: { email: false, inApp: false },
+  newDatasets: { email: false, inApp: false },
+  systemMaintenance: { email: false, inApp: false },
+  systemErrors: { email: false, inApp: false },
+};
+
+const isBoolean = (value: unknown): value is boolean =>
+  typeof value === "boolean";
+
+const isNotificationToggle = (
+  value: unknown,
+): value is { email: boolean; inApp: boolean } => {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return isBoolean(candidate.email) && isBoolean(candidate.inApp);
+};
+
+export const validateNotificationSettingsValue = (
+  value: unknown,
+): value is NotificationSettingsValue => {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    isNotificationToggle(candidate.newFeatures) &&
+    isNotificationToggle(candidate.datasetLibraryChanges) &&
+    isNotificationToggle(candidate.newDatasets) &&
+    isNotificationToggle(candidate.systemMaintenance) &&
+    isNotificationToggle(candidate.systemErrors)
+  );
+};
+
+export const parseNotificationSettingsValue = (
+  value: string | null | undefined,
+): NotificationSettingsValue | null => {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!validateNotificationSettingsValue(parsed)) return null;
+    return parsed;
+  } catch (error) {
+    logError("Failed to parse notification settings value", error);
+    return null;
+  }
+};
+
+export const getLatestUserSetting = (settings: UserSettings[]) => {
+  if (settings.length === 0) return null;
+  const withTimestamps = settings.filter(
+    (setting) => setting.updatedAt || setting.createdAt,
+  );
+  if (withTimestamps.length === 0) {
+    return settings[settings.length - 1];
+  }
+  return withTimestamps.slice().sort((a, b) => {
+    const aTime = new Date(a.updatedAt || a.createdAt || 0).getTime() || 0;
+    const bTime = new Date(b.updatedAt || b.createdAt || 0).getTime() || 0;
+    return bTime - aTime;
+  })[0];
+};
+
+export const buildNotificationSettingsPayload = (
+  settings: NotificationSettingsValue & { id?: string; eTag?: string | null },
+): {
+  key: string;
+  value: NotificationSettingsValue;
+  id?: string;
+  eTag?: string | null;
+} => {
+  const { id, eTag, ...value } = settings;
+  return {
+    key: NOTIFICATION_SETTINGS_KEY,
+    value,
+    id,
+    eTag,
+  };
+};
+
+export const saveNotificationSettings = async (
+  api: ReturnType<typeof useApi>,
+  settings: NotificationSettingsValue & { id?: string; eTag?: string | null },
+) => {
+  if (!validateNotificationSettingsValue(settings)) {
+    throw new Error("Invalid notification settings schema");
+  }
+  const payload = buildNotificationSettingsPayload(settings);
+  return api.saveUserSettings(payload, settings.id);
+};

--- a/src/types/userDirectory.ts
+++ b/src/types/userDirectory.ts
@@ -1,0 +1,47 @@
+export interface User {
+  id?: string | null;
+  name?: string | null;
+  email?: string | null;
+  idpSubjectId?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  eTag?: string | null;
+}
+
+export interface UserQueryResult {
+  items?: User[] | null;
+  count?: number;
+}
+
+export interface UserGroup {
+  id?: string | null;
+  name?: string | null;
+  semantics?: string[] | null;
+}
+
+export interface UserGroupQueryResult {
+  items?: UserGroup[] | null;
+  count?: number;
+}
+
+export interface UserLookup {
+  ids?: string[] | null;
+  excludedIds?: string[] | null;
+  idpSubjectIds?: string[] | null;
+  like?: string | null;
+  page?: Record<string, unknown>;
+  order?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  project?: Record<string, unknown>;
+}
+
+export interface UserGroupLookup {
+  ids?: string[] | null;
+  excludedIds?: string[] | null;
+  semantics?: string[] | null;
+  like?: string | null;
+  page?: Record<string, unknown>;
+  order?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  project?: Record<string, unknown>;
+}

--- a/src/types/userSettings.ts
+++ b/src/types/userSettings.ts
@@ -1,0 +1,15 @@
+export interface UserSettings {
+  id?: string;
+  key?: string;
+  value?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  eTag?: string | null;
+}
+
+export interface UserSettingsPersist {
+  id?: string;
+  key?: string;
+  value?: unknown;
+  eTag?: string | null;
+}


### PR DESCRIPTION
- Added 3-tab settings navigation with active underline styling  
- Rebuilt Personal Settings layout to match Figma (Basic Info rows)  
- Replaced editable inputs with read-only pills matching design  
- Added user avatar/name/email display with role chip  
- Adjusted spacing and responsiveness across rows and delete button  
- Updated settings container spacing to match Browse layout

- UserProfile: wired notification settings to User Settings API (load/save/reset/delete) with toasts and change tracking.
- DatasetPermissionsModal: added modal for dataset permissions with group loading from API and user lookup on invite.
- ManageGroupsModal: added groups management modal with API-backed group search and empty state.
- PersonalSettingsSection: updated personal settings layout to show basic info, account name, and delete account action.
- PreferencesSection: added save/delete-saved actions and disabled states tied to notification changes.
- PreferencesSection.test: added tests for notification preferences rendering and toggle behavior.
- RolesPermissionsSection: added roles & permissions UI with API-loaded group filter options and dataset permissions modal entry.
- RolesPermissionsSection.test: added tests for roles & permissions section behavior.
- TabsHeader: updated tabs configuration and labels for Personal settings, Notifications, and Roles & Permissions.