### PR TITLE
DG-106|Changes for role permissions

### DIFF
--- a/docs/API_VERIFICATION_REPORT.md
+++ b/docs/API_VERIFICATION_REPORT.md
@@ -1,0 +1,108 @@
+# Raport weryfikacji API – Swagger vs dokumentacja vs implementacja
+
+**Data:** 16 lutego 2025  
+**Źródła:**
+- [Swagger](https://datagems-dev.scayle.es/gw/swagger/index.html)
+- [Data flows](https://datagems-eosc.github.io/dg-app-api/latest/data-flows/)
+- [Onboarding / Postman](https://datagems-eosc.github.io/dg-app-api/latest/onboarding/)
+- [Postman collection](https://datagems-eosc.github.io/dg-app-api/latest/content/DataGEMS.dg-app-api.postman-collection.json)
+
+---
+
+## 1. Onboarding flow
+
+### 1.1 Upload plików
+
+| Aspekt | Swagger/Docs | Implementacja |
+|--------|--------------|---------------|
+| Endpoint | `POST /api/storage/upload/dataset` | Zgodne (`uploadDatasetFiles`) |
+| Format | `multipart/form-data`, pola `file1`, `file2`… | Zgodne |
+| Odpowiedź | Tablica ścieżek staged | Obsługiwane (`stagedPath`) |
+
+### 1.2 Onboard dataset
+
+| Pole | Docs (PascalCase) | Nasz `onboardDataset` |
+|------|-------------------|------------------------|
+| Description | ✓ | ✓ |
+| License | ✓ | ✓ |
+| MimeType | ✓ | ✓ |
+| Size | ✓ | ✓ |
+| Url | ✓ | ✓ |
+| DataLocations | Kind, **Location** | Kind, **Location** ✓ |
+| CiteAs, ConformsTo | W docs | ✓ |
+
+**Uwaga z piotr.sikora:** Metadane (url, mimeType, size) są **w całości podawane przez użytkownika**. Brak automatycznego wyciągania z uploadu.
+
+Różnica Postman vs docs: w Postman `DataLocations` ma pole `url`, w docs – `Location`. **Nasza implementacja używa `Location`** – zgodnie z docs.
+
+### 1.3 Profilowanie
+
+- Endpoint: `POST /api/dataset/profile`
+- Body: `{ "id": "<uuid>", "dataStoreKind": 0 }` (0 = FileSystem)
+- Zgodne z implementacją.
+
+---
+
+## 2. User Group Query
+
+### 2.1 Endpoint
+
+- **Swagger:** `POST /api/user/group/query`
+- **Full URL:** `{baseUrl}/gw/api/user/group/query`
+- **Implementacja:** `NEXT_PUBLIC_USER_GROUPS_ENDPOINT` lub `/user/group/query` ✓
+
+### 2.2 Schemat UserGroupLookup (Swagger)
+
+```
+ids?: string[] | null
+excludedIds?: string[] | null
+semantics?: string[] | null
+like?: string | null     // Limit lookup to items whose name matches the pattern
+page?: Paging            // offset, size (camelCase w OpenAPI)
+order?: Ordering         // items (camelCase w OpenAPI)
+metadata?: Header        // countAll
+project?: FieldSet       // fields
+```
+
+### 2.3 Różnica Postman vs Swagger
+
+Kolekcja Postman używa **PascalCase** dla zapytań:
+
+```json
+{
+  "page": { "Offset": 0, "Size": 10 },
+  "Order": { "Items": ["+code"] },
+  "Metadata": { "CountAll": true }
+}
+```
+
+Swagger/OpenAPI ma **camelCase** (`offset`, `size`, `items`), ale backend (.NET) w praktyce może oczekiwać PascalCase.
+
+### 2.4 Obecny payload
+
+```ts
+queryUserGroups(search.trim() ? { like: search.trim() } : {})
+```
+
+**Uwaga:** Endpoint zwraca 102 Validation Error dla Page/Order - NIE wysyłać tych pól.
+
+
+---
+
+## 3. Context grants (przypisanie grup do datasetu)
+
+| Aspekt | Swagger | Implementacja |
+|--------|---------|----------------|
+| Endpoint | `POST /api/principal/context-grants/group/{groupId}/dataset/{datasetId}/role/{role}` | ✓ `assignGroupDatasetGrant` |
+| Usuwanie | `DELETE` ten sam path | ✓ `unassignGroupDatasetGrant` |
+
+---
+
+## 4. Rekomendacje
+
+1. **`queryUserGroups`** – minimalny payload: `{}` lub `{ like: "fraza" }`; NIE wysyłać `page` ani `Order` (backend zwraca Validation Error)
+2. **Onboarding** – obecna implementacja jest zgodna z docs.
+3. **Debugowanie grup** – sprawdzić w Network Tab:
+   - status HTTP
+   - body requestu i response
+   - czy backend zwraca 401/403 (autoryzacja/uprawnienia).

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -5,10 +5,12 @@ import { useEffect, useMemo, useState } from "react";
 import DashboardLayout from "@/components/DashboardLayout";
 import DatasetDetailsPageContent from "@/components/DatasetDetailsPage/DatasetDetailsPageContent";
 import { APP_ROUTES } from "@/config/appUrls";
+import { DATASET_ROLE_MAP } from "@/config/contextGrantRoles";
 import type { DatasetPlus } from "@/data/dataset";
 import { useApi } from "@/hooks/useApi";
-import { logApiError } from "@/lib/logger";
+import { logApiError, logWarn } from "@/lib/logger";
 import { getNavigationUrl } from "@/lib/utils";
+import type { ContextGrant } from "@/types/contextGrants";
 
 export default function DatasetDetailsPage() {
   const params = useParams();
@@ -108,7 +110,37 @@ export default function DatasetDetailsPage() {
         }
 
         const apiDataset = items[0];
-        const mappedDataset = mapApiDatasetToDatasetPlus(apiDataset);
+        let mappedDataset = mapApiDatasetToDatasetPlus(apiDataset);
+        const hasManageFromDataset = mappedDataset.permissions?.some(
+          (p) => p.toLowerCase() === "manage",
+        );
+        if (!hasManageFromDataset) {
+          try {
+            const grants: ContextGrant[] =
+              await api.getCurrentUserContextGrants();
+            if (isCancelled) return;
+            const hasManageFromGrants = grants.some(
+              (g) =>
+                g.targetType === 0 &&
+                g.targetId === datasetId &&
+                g.role
+                  ?.toLowerCase()
+                  .includes(DATASET_ROLE_MAP.manage.toLowerCase()),
+            );
+            if (hasManageFromGrants) {
+              mappedDataset = {
+                ...mappedDataset,
+                permissions: [...(mappedDataset.permissions ?? []), "Manage"],
+              };
+            }
+          } catch (grantsErr) {
+            logWarn("Failed to fetch context grants for dataset permissions", {
+              datasetId,
+              error: grantsErr,
+            });
+          }
+        }
+        if (isCancelled) return;
         setDataset(mappedDataset);
         setIsLoading(false);
       } catch (err) {
@@ -221,10 +253,16 @@ function mapApiDatasetToDatasetPlus(api: unknown): DatasetPlus {
   let permissionArray: string[] = [];
   if (typeof permissions === "object" && permissions !== null) {
     const permObj = permissions as Record<string, unknown>;
-    if (permObj.browseDataset) permissionArray.push("Browse");
-    if (permObj.editDataset) permissionArray.push("Edit");
-    if (permObj.downloadDataset) permissionArray.push("Download");
-    if (permObj.manageDataset) permissionArray.push("Manage");
+    const hasPermission = (camel: string, pascal: string) =>
+      Boolean(permObj[camel]) || Boolean(permObj[pascal]);
+    if (hasPermission("browseDataset", "BrowseDataset"))
+      permissionArray.push("Browse");
+    if (hasPermission("editDataset", "EditDataset"))
+      permissionArray.push("Edit");
+    if (hasPermission("downloadDataset", "DownloadDataset"))
+      permissionArray.push("Download");
+    if (hasPermission("manageDataset", "ManageDataset"))
+      permissionArray.push("Manage");
   } else if (Array.isArray(permissions)) {
     permissionArray = permissions.map(String);
   }

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetPermissionsSection.test.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetPermissionsSection.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DatasetPermissionsSection from "./DatasetPermissionsSection";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const defaultProps = {
+  datasetId: "ds-123",
+  datasetName: "Test Dataset",
+  hasBrowsePermission: true,
+  hasEditPermission: false,
+  hasDownloadPermission: false,
+  hasManagePermission: false,
+  permissions: ["Browse"],
+};
+
+describe("DatasetPermissionsSection", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it("renders Your Permissions title and permission chips", () => {
+    const { container } = render(
+      <DatasetPermissionsSection {...defaultProps} />,
+    );
+    const section = container.firstChild as HTMLElement;
+
+    expect(within(section).getByText("Your Permissions")).toBeInTheDocument();
+    expect(within(section).getByText("Browse")).toBeInTheDocument();
+  });
+
+  it("displays Browse chip when user has only browse permission", () => {
+    const { container } = render(
+      <DatasetPermissionsSection {...defaultProps} />,
+    );
+    const section = container.firstChild as HTMLElement;
+
+    expect(within(section).getByText("Browse")).toBeInTheDocument();
+    expect(
+      within(section).queryByRole("button", { name: /manage/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays Browse and Edit chips when user has edit permission", () => {
+    const { container } = render(
+      <DatasetPermissionsSection
+        {...defaultProps}
+        hasEditPermission
+        permissions={["Browse", "Edit"]}
+      />,
+    );
+    const section = container.firstChild as HTMLElement;
+
+    expect(within(section).getByText("Browse")).toBeInTheDocument();
+    expect(within(section).getByText("Edit")).toBeInTheDocument();
+    expect(
+      within(section).queryByRole("button", { name: /manage/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays Manage button and permission chips when user has manage permission", () => {
+    const { container } = render(
+      <DatasetPermissionsSection
+        {...defaultProps}
+        hasManagePermission
+        permissions={["Browse", "Edit", "Manage"]}
+      />,
+    );
+    const section = container.firstChild as HTMLElement;
+
+    expect(within(section).getByText("Browse")).toBeInTheDocument();
+    expect(within(section).getByText("Edit")).toBeInTheDocument();
+    expect(
+      within(section).getAllByText("Manage").length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      within(section).getByRole("button", { name: /manage/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates to settings roles with datasetId when Manage is clicked", () => {
+    const { container } = render(
+      <DatasetPermissionsSection
+        {...defaultProps}
+        hasManagePermission
+        datasetId="ds-456"
+        permissions={["Manage"]}
+      />,
+    );
+    const section = container.firstChild as HTMLElement;
+
+    fireEvent.click(within(section).getByRole("button", { name: /manage/i }));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const pushedUrl = mockPush.mock.calls[0][0];
+    expect(pushedUrl).toContain("settings");
+    expect(pushedUrl).toContain("tab=roles");
+    expect(pushedUrl).toContain("datasetId=ds-456");
+  });
+
+  it("navigates to settings roles without datasetId when datasetId is empty", () => {
+    const { container } = render(
+      <DatasetPermissionsSection
+        {...defaultProps}
+        datasetId=""
+        hasManagePermission
+        permissions={["Manage"]}
+      />,
+    );
+    const section = container.firstChild as HTMLElement;
+
+    fireEvent.click(within(section).getByRole("button", { name: /manage/i }));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const pushedUrl = mockPush.mock.calls[0][0];
+    expect(pushedUrl).toContain("settings");
+    expect(pushedUrl).toContain("tab=roles");
+    expect(pushedUrl).not.toContain("datasetId=");
+  });
+
+  it("displays Viewer chip when permissions array is empty", () => {
+    const { container } = render(
+      <DatasetPermissionsSection
+        {...defaultProps}
+        permissions={[]}
+        hasEditPermission={false}
+        hasDownloadPermission={false}
+        hasManagePermission={false}
+      />,
+    );
+    const section = container.firstChild as HTMLElement;
+
+    expect(within(section).getByText("Viewer")).toBeInTheDocument();
+  });
+});

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetPermissionsSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetPermissionsSection.tsx
@@ -8,7 +8,14 @@ import { APP_ROUTES } from "@/config/appUrls";
 import { getNavigationUrl } from "@/lib/utils";
 import styles from "./DatasetSidebarSection.module.scss";
 
-type PermissionLevel = "Owner" | "Editor" | "Viewer";
+const PERMISSION_LABELS: Record<string, string> = {
+  Browse: "Browse",
+  Edit: "Edit",
+  Download: "Download",
+  Manage: "Manage",
+};
+
+const PERMISSION_ORDER = ["Browse", "Edit", "Download", "Manage"];
 
 interface DatasetPermissionsSectionProps {
   datasetId: string;
@@ -20,33 +27,30 @@ interface DatasetPermissionsSectionProps {
   permissions: string[];
 }
 
-function getPermissionLevel(
-  hasManagePermission: boolean,
-  hasEditPermission: boolean,
-  hasDownloadPermission: boolean,
-): PermissionLevel {
-  if (hasManagePermission) return "Owner";
-  if (hasEditPermission || hasDownloadPermission) return "Editor";
-  return "Viewer";
-}
-
 export default function DatasetPermissionsSection({
   datasetId,
-  hasBrowsePermission: _hasBrowsePermission,
-  hasEditPermission,
-  hasDownloadPermission,
   hasManagePermission,
   permissions,
   datasetName: _datasetName,
 }: DatasetPermissionsSectionProps) {
   const router = useRouter();
-  const level = getPermissionLevel(
-    hasManagePermission,
-    hasEditPermission,
-    hasDownloadPermission,
+
+  const displayPermissions = PERMISSION_ORDER.filter((key) =>
+    permissions.some((p) => p.toLowerCase() === key.toLowerCase()),
   );
 
-  const displayLevel = permissions.length === 0 ? "Viewer" : level;
+  const permissionChips =
+    displayPermissions.length > 0
+      ? displayPermissions.map((key) => (
+          <Chip key={key} color="grey" variant="regular" size="sm">
+            {PERMISSION_LABELS[key] ?? key}
+          </Chip>
+        ))
+      : [
+          <Chip key="viewer" color="grey" variant="regular" size="sm">
+            Viewer
+          </Chip>,
+        ];
 
   return (
     <div className={styles.datasetSidebarSection}>
@@ -54,7 +58,7 @@ export default function DatasetPermissionsSection({
         <div className={styles.datasetSidebarSection__headerLeft}>
           <Lock className={styles.datasetSidebarSection__icon} />
           <h3 className={styles.datasetSidebarSection__title}>
-            Your permission
+            Your Permissions
           </h3>
         </div>
         {hasManagePermission && (
@@ -77,9 +81,9 @@ export default function DatasetPermissionsSection({
           </Button>
         )}
       </div>
-      <Chip color="info" variant="outline" size="sm">
-        {displayLevel}
-      </Chip>
+      <div className={styles.datasetSidebarSection__chips}>
+        {permissionChips}
+      </div>
     </div>
   );
 }

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetSidebarSection.module.scss
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetSidebarSection.module.scss
@@ -4,6 +4,7 @@
   @include flex-column;
   gap: $spacing-lg;
   width: 100%;
+  align-items: flex-start;
 
   &__header {
     @include flex-between;

--- a/src/components/DatasetDetailsPage/FilePreview/FilePreview.tsx
+++ b/src/components/DatasetDetailsPage/FilePreview/FilePreview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import type {
   FileColumn,
@@ -15,9 +16,12 @@ import FilePreviewHeader from "./FilePreviewHeader";
 import FilePreviewTable from "./FilePreviewTable";
 import FilePreviewTabs from "./FilePreviewTabs";
 import JsonFilePreview from "./JsonFilePreview";
-import PdfFilePreview from "./PdfFilePreview";
 import ShowColumnsModal from "./ShowColumnsModal";
 import StatisticsTab from "./StatisticsTab";
+
+const PdfFilePreview = dynamic(() => import("./PdfFilePreview"), {
+  ssr: false,
+});
 
 interface FilePreviewProps {
   fileData: FilePreviewDataUnion | null;


### PR DESCRIPTION
Summary of changes:
Dataset details page: added PascalCase support in API permission mapping (ManageDataset, EditDataset, etc.)
Dataset details page: added context grants fallback to derive Manage permission when dataset API omits it
DatasetPermissionsSection: renamed "Your permission" to "Your Permissions"
DatasetPermissionsSection: replaced single level chip with individual permission chips (Browse, Edit, Download, Manage) per Figma
DatasetPermissionsSection: Manage button uses the same outline styling as the Add button
DatasetPermissionsSection tests: updated for the new structure and behavior