### PR TITLE
fix: redirect loop on protected routes for anonymous users

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -52,12 +52,6 @@ const handler = NextAuth({
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,
-  pages: {
-    signIn: "/api/auth/signin",
-    signOut: "/api/auth/signout",
-    error: "/api/auth/error",
-    verifyRequest: "/api/auth/verify-request",
-  },
   session: {
     strategy: "jwt",
     maxAge: 30 * 24 * 60 * 60, // 30 days

--- a/src/components/ProtectedPage/ProtectedPage.tsx
+++ b/src/components/ProtectedPage/ProtectedPage.tsx
@@ -19,7 +19,7 @@ export default function ProtectedPage({
         windowLocation:
           typeof window !== "undefined" ? window.location.href : null,
       });
-      signIn();
+      signIn("keycloak");
     }
   }, [status, session]);
 


### PR DESCRIPTION
## Summary

Anonymous users hitting `/browse` (or any `<ProtectedPage>`-wrapped route) saw `ERR_TOO_MANY_REDIRECTS` instead of being sent to login.

## Root cause

Two related bugs in NextAuth wiring:

1. **`ProtectedPage.tsx:22`** called `signIn()` without a provider argument. NextAuth then routes to `pages.signIn`.
2. **`route.ts` `pages` block** had `signIn: \"/api/auth/signin\"` — pointing at NextAuth's *own* default API route. NextAuth interprets `pages.signIn` as a custom page and redirects to it; the destination is the default handler, which sees `pages.signIn` configured and redirects to the \"custom page\" (itself). Infinite server-side 302 loop.

Confirmed via curl on production:
\`\`\`
GET /api/auth/signin?callbackUrl=...
→ 302 location: /api/auth/signin?callbackUrl=...   (same URL)
→ 302 location: /api/auth/signin?callbackUrl=...   (same URL again)
... browser kills it at ~20 hops with ERR_TOO_MANY_REDIRECTS
\`\`\`

The home page (`/`) was unaffected because `LoginScreen` calls `signIn(\"keycloak\")` *with* a provider arg, which routes through `/api/auth/signin/keycloak` (a different NextAuth route that doesn't read `pages.signIn`).

## Fix

- `ProtectedPage` now calls `signIn(\"keycloak\")` — direct redirect to Keycloak with `callbackUrl` defaulting to the current page. Matches `LoginScreen`.
- Removed the entire `pages` config block. Each entry pointed at NextAuth's own default API route at the same path — the same self-redirect trap also lurked on `signOut`, `error`, and `verifyRequest` flows. Without the block, NextAuth uses its built-in handlers correctly. No user-visible change for those flows on the happy path; they just stop being a hidden landmine.

## Local verification

- [x] Biome — 307 files, no issues
- [x] TypeScript — clean
- [x] Tests — 79/79 pass
- [x] Build — succeeded

## Test plan

- [ ] CI green
- [ ] Visit `/browse` while signed out → land on Keycloak, not on a redirect-loop browser error
- [ ] Sign in flow from `/` still works (sanity check, unchanged path)
- [ ] After sign-in from `/browse`, user lands back on `/browse` (not `/`)