### PR TITLE
chore: load deployment config from .env instead of hardcoded values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# =====================================================================
+# DataGEMS Frontend — environment configuration
+# =====================================================================
+# Copy this file to `.env` and fill in values for your environment.
+# `.env` is git-ignored; this template is the only versioned reference.
+#
+# docker-compose automatically reads `.env` from the same directory and
+# substitutes ${VAR} references in docker-compose.yml.
+#
+#   cp .env.example .env
+#   $EDITOR .env
+#   docker-compose up -d --build
+# =====================================================================
+
+# ---- Required ----------------------------------------------------------
+
+# Public app URL — must match the URL users access in their browser.
+# Used for cookie domain, OAuth redirect URIs, and public links.
+NEXT_PUBLIC_APP_BASE_URL=https://datagems-frontend.example.com
+
+# NextAuth canonical URL. Must match NEXT_PUBLIC_APP_BASE_URL.
+NEXTAUTH_URL=https://datagems-frontend.example.com
+
+# NextAuth session-signing secret. Generate with: openssl rand -hex 32
+NEXTAUTH_SECRET=replace-with-a-strong-random-secret
+
+# Keycloak realm issuer URL.
+KEYCLOAK_ISSUER=https://datagems-dev.scayle.es/oauth/realms/dev
+
+# ---- Optional (defaults shown) -----------------------------------------
+
+# Host port to bind to the container (default 3000).
+FRONTEND_PORT=3000
+
+# Base path when serving from a subdirectory, e.g. /myapp. Empty for root.
+NEXT_PUBLIC_BASE_PATH=
+
+# DataGEMS API gateway base URL.
+NEXT_PUBLIC_DATAGEMS_API_BASE_URL=https://datagems-dev.scayle.es
+
+# Keycloak client identifiers (PKCE public client — secret stays empty).
+KEYCLOAK_CLIENT_ID=dg-app-ui
+KEYCLOAK_CLIENT_SECRET=
+
+# Node runtime mode.
+NODE_ENV=production

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ARG NEXT_PUBLIC_BASE_PATH=""
 ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
 
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN pnpm run build
 
 # Production image, copy all the files and run next

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,22 +3,24 @@ services:
     build:
       context: .
       args:
-        NEXT_PUBLIC_BASE_PATH: /ui
+        NEXT_PUBLIC_BASE_PATH: ${NEXT_PUBLIC_BASE_PATH:-}
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     environment:
-      - NODE_ENV=production
+      - NODE_ENV=${NODE_ENV:-production}
       - NEXT_TELEMETRY_DISABLED=1
       - KEYCLOAK_AUTH_GRAND_TYPE=PKCE
-      - KEYCLOAK_CLIENT_ID=dg-app-ui
-      - KEYCLOAK_CLIENT_SECRET="" # (empty string, not used)
-      - KEYCLOAK_ISSUER=https://datagems-dev.scayle.es/oauth/realms/dev
-      - NEXT_PUBLIC_APP_BASE_URL=http://localhost:${FRONTEND_PORT:-3000}
-      - NEXTAUTH_URL=http://localhost:${FRONTEND_PORT:-3000}
-      - NEXTAUTH_SECRET=your-secret-key-here-change-in-production
+      - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-dg-app-ui}
+      - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET:-}
+      - KEYCLOAK_ISSUER=${KEYCLOAK_ISSUER:?KEYCLOAK_ISSUER must be set in .env}
+      - NEXT_PUBLIC_BASE_PATH=${NEXT_PUBLIC_BASE_PATH:-}
+      - NEXT_PUBLIC_APP_BASE_URL=${NEXT_PUBLIC_APP_BASE_URL:?NEXT_PUBLIC_APP_BASE_URL must be set in .env}
+      - NEXT_PUBLIC_DATAGEMS_API_BASE_URL=${NEXT_PUBLIC_DATAGEMS_API_BASE_URL:-https://datagems-dev.scayle.es}
+      - NEXTAUTH_URL=${NEXTAUTH_URL:?NEXTAUTH_URL must be set in .env}
+      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:?NEXTAUTH_SECRET must be set in .env}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/healthz"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

Eliminates the need for server operators to maintain local patches to versioned files (`Dockerfile`, `docker-compose.yml`). Production env (URL, secrets, Keycloak issuer) now lives in a per-machine `.env` file; the compose file only interpolates values.

## Why

`docker-compose.yml` had hardcoded development defaults (`http://localhost:3000`, `your-secret-key-here-change-in-production`, ...). The production host was working around this by editing the versioned file directly, which:

- Created merge conflicts on every `git pull` (currently blocking deployment).
- Risked leaking real `NEXTAUTH_SECRET` if anyone committed the modified file.
- Hid drift between dev and prod configs.

## Changes

- **`docker-compose.yml`** — every environment-specific value moved to `${VAR}` interpolation:
  - Required vars (`NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `NEXT_PUBLIC_APP_BASE_URL`, `KEYCLOAK_ISSUER`) use `${VAR:?...}` so compose refuses to start with a clear message if missing.
  - Optional vars use `${VAR:-default}` for sensible fallbacks.
  - Healthcheck `curl` → `wget` (the alpine runtime image doesn't ship `curl`; the compose-level healthcheck overrides the Dockerfile one and was silently failing).
- **`.env.example`** — new versioned template documenting every variable. Operators copy to `.env` and edit.
- **`.gitignore`** — `!.env.example` exception so the template is tracked while `.env` stays local.
- **`Dockerfile`** — adds `ENV NODE_OPTIONS=--max-old-space-size=4096` before the Next.js build. Matches what the production server has been patching locally; Next.js builds OOM on hosts with <4 GB.

## Operator runbook (post-merge)

```bash
# on the deployment host
git stash drop          # discard the local Dockerfile/docker-compose.yml patches
git pull
cp .env.example .env    # if it doesn't already exist
$EDITOR .env            # set real values: APP_BASE_URL, NEXTAUTH_URL, NEXTAUTH_SECRET, KEYCLOAK_ISSUER
docker-compose up -d --build
```

## Verification

- [x] `docker compose config` without `.env` fails loudly: `required variable KEYCLOAK_ISSUER is missing a value: KEYCLOAK_ISSUER must be set in .env`
- [x] `docker compose config --env-file .env.example` resolves cleanly
- [x] `git check-ignore .env-probe` confirms `.env*` is ignored
- [x] `git check-ignore .env.example` confirms the template is tracked
- [x] Biome / type-check / tests pass (no app code touched, only config)

## Out of scope (noted for later)

- `dist.env` at the repo root is a half-template with shell-style inline comments that aren't valid in a docker-compose `.env`. Did not touch it. Worth replacing with `.env.example` in a follow-up.
- `KEYCLOAK_AUTH_GRAND_TYPE` (typo of `GRANT`) in `docker-compose.yml` is unused by app code (`grep` confirms). Left untouched to keep this PR minimal.