### PR TITLE
fix: container healthcheck unhealthy due to IPv6/IPv4 mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ ENV HOSTNAME="0.0.0.0"
 
 # Health check configuration
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD wget -q --spider http://localhost:3000/healthz || exit 1
+  CMD wget -q --spider http://127.0.0.1:3000/healthz || exit 1
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:?NEXTAUTH_SECRET must be set in .env}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/healthz"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

Container had been running with `unhealthy` Docker status since the previous deploy, even though the app served traffic correctly through nginx. Root cause: busybox `wget` in alpine resolves `localhost` to `::1` (IPv6) first, but Next.js binds only to `0.0.0.0` (IPv4) via the `HOSTNAME` env var. `wget` gets connection refused.

Healthcheck logs from the affected container:
\`\`\`
"Output": "wget: can't connect to remote host: Connection refused\n"
\`\`\`

## Fix

Replace `localhost` with `127.0.0.1` in the healthcheck URL — forces IPv4 directly, hits the listening socket, healthcheck flips to healthy.

Applied in two places kept in sync:
- `docker-compose.yml` healthcheck (the active one — it overrides the Dockerfile-level)
- `Dockerfile` HEALTHCHECK directive (latent fallback if compose override is removed)

## Verification

- [x] Biome — clean
- [x] type-check — clean
- (no app code touched, only Docker config)

## Test plan after merge & redeploy

- [ ] `docker compose ps` — STATUS column shows `healthy` (not `unhealthy` or `starting` after the 40s start period)
- [ ] `docker inspect --format='{{json .State.Health}}' dg-app-ui-frontend-1` — recent healthcheck entries show `ExitCode: 0`
- [ ] App still serves traffic normally (sanity)