### PR TITLE
fix(DG-164): refresh access token on 401 instead of forced logout

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { type ClassValue, clsx } from "clsx";
+import { getSession } from "next-auth/react";
 import { twMerge } from "tailwind-merge";
 import { publicEnv } from "./env";
 import { logError } from "./logger";
@@ -78,26 +79,68 @@ export function getApiBaseUrl(): string {
 }
 
 /**
- * Wrapper for fetch that logs out the user (redirects to /logout) on 401 Unauthorized.
- * Use this for all authenticated API calls in the browser.
+ * Wrapper for fetch that handles auth on 401 responses:
+ *   1. Forces a session refresh via getSession() — NextAuth's JWT callback
+ *      runs and exchanges the refresh_token for a new access_token if the
+ *      current one has just expired.
+ *   2. Retries the original request once with the fresh token.
+ *   3. Only if the retry still returns 401 (or refresh itself failed) does
+ *      the user get redirected to /logout.
  *
- * @param input - RequestInfo (URL or Request object)
- * @param init - RequestInit (fetch options)
- * @returns Promise<Response>
+ * Use this for all authenticated API calls in the browser.
  */
 export async function fetchWithAuth(
   input: RequestInfo,
   init?: RequestInit,
 ): Promise<Response> {
-  const response = await fetch(input, init);
-  if (response.status === 401 && typeof window !== "undefined") {
-    if (window.location.pathname !== getLogoutUrl()) {
-      window.location.href = getLogoutUrl();
-    }
-    // Prevent further code execution
-    return new Response(null, { status: 401, statusText: "Unauthorized" });
+  let response = await fetch(input, init);
+
+  if (response.status !== 401 || typeof window === "undefined") {
+    return response;
   }
+
+  let freshSession: any = null;
+  try {
+    freshSession = await getSession();
+  } catch (error) {
+    logError("Session refresh failed during 401 retry", error);
+  }
+
+  const newToken: string | undefined = freshSession?.accessToken;
+  const refreshFailed = freshSession?.error === "RefreshAccessTokenError";
+
+  if (!newToken || refreshFailed) {
+    return forceLogoutResponse();
+  }
+
+  const retryHeaders = new Headers(init?.headers);
+  const previousToken = retryHeaders
+    .get("Authorization")
+    ?.replace(/^Bearer\s+/i, "");
+
+  if (previousToken && previousToken === newToken) {
+    return forceLogoutResponse();
+  }
+
+  retryHeaders.set("Authorization", `Bearer ${newToken}`);
+  if (retryHeaders.has("oauth2")) {
+    retryHeaders.set("oauth2", newToken);
+  }
+
+  response = await fetch(input, { ...init, headers: retryHeaders });
+
+  if (response.status === 401) {
+    return forceLogoutResponse();
+  }
+
   return response;
+}
+
+function forceLogoutResponse(): Response {
+  if (window.location.pathname !== getLogoutUrl()) {
+    window.location.href = getLogoutUrl();
+  }
+  return new Response(null, { status: 401, statusText: "Unauthorized" });
 }
 
 /**


### PR DESCRIPTION
Closes #164

## Summary

Users were being kicked out every ~3 minutes regardless of activity. \`fetchWithAuth\` treated any 401 from the backend as a terminal session loss and redirected to \`/logout\` — without giving NextAuth a chance to refresh the access token. This PR turns that one-shot logout into a refresh-and-retry.

## Root cause

NextAuth's JWT callback already implements correct refresh logic (exchanges \`refresh_token\` for a new \`access_token\` via Keycloak), but it only runs on the periodic session refetch (\`refetchInterval: 60\` in \`SessionProviderWrapper\`). Any API call made during the window between access_token expiry (~3 min in this Keycloak realm) and the next 60 s refetch tick returned 401, and \`fetchWithAuth\` then forced a logout before refresh could happen.

## Fix

In \`src/lib/utils.ts\`, \`fetchWithAuth\` now:

1. Sends the original request as before.
2. On 401, calls \`getSession()\` — this triggers \`/api/auth/session\`, which runs the JWT callback, which refreshes the token if it's near expiry.
3. Retries the original request with the fresh \`Authorization\` and \`oauth2\` headers.
4. Only force-logs-out if refresh itself failed (\`session.error === \"RefreshAccessTokenError\"\`), no new token was issued, or the retried request still returned 401.

\`SessionErrorHandler\` in \`SessionProviderWrapper\` is kept as a safety net for idle users (no API activity → scheduled refetch detects a fundamentally broken refresh).

## Acceptance criteria

> If an API call returns a 401 Unauthorized error, the frontend must intercept this, attempt a token refresh, and retry the original request without user interruption.

Satisfied.

## Local verification

- [x] \`pnpm run lint:biome:check\` — clean
- [x] \`pnpm run type-check\` — clean
- [x] \`pnpm test\` — 79/79 pass
- [x] \`pnpm run build\` — succeeded

## Test plan after deploy

In a logged-in session:
- [ ] Wait through one or two access_token lifetimes (~3 min × 2) without making any API call. Then click around — requests should succeed, no automatic logout.
- [ ] Open DevTools → Network. After ~3 min, trigger an API request (e.g. open \`/browse\`). Expect: first response 401, immediately followed by a \`/api/auth/session\` call, then the same API endpoint retried with a new \`Authorization\` header → 200.
- [ ] Verify no spurious \`/logout\` redirect during the above.

## Out of scope (follow-ups)

- The XHR upload path in \`useApi.uploadDatasetFiles\` still has the original 401 → logout behavior. Uploads are typically short-lived enough to not hit token expiry mid-flight; a clean retry on a half-uploaded XHR needs separate handling.