### PR TITLE
fix(DG-160): wire Delete in collection 3-dots dropdown, revert sidebar removal

### DIFF
--- a/src/app/collections/custom/[id]/page.tsx
+++ b/src/app/collections/custom/[id]/page.tsx
@@ -179,6 +179,72 @@ export default function CustomCollectionPage() {
     }
   };
 
+  const handleBulkRemoveSelectedDatasets = async (datasetIds: string[]) => {
+    if (!collection?.id || datasetIds.length === 0) return;
+    const collectionId = collection.id;
+    const collectionName = collection.name;
+
+    // Optimistic UI: remove from edited list (used for display in edit mode)
+    // and clear selection.
+    const previousIds = editedDatasetIds;
+    const previousSelection = selectedDatasets;
+    const removeSet = new Set(datasetIds);
+    setEditedDatasetIds((prev) => prev.filter((id) => !removeSet.has(id)));
+    setSelectedDatasets([]);
+
+    const results = await Promise.allSettled(
+      datasetIds.map((id) =>
+        api.removeDatasetFromUserCollection(collectionId, id),
+      ),
+    );
+    const failures = results
+      .map((result, index) => ({ result, datasetId: datasetIds[index] }))
+      .filter(({ result }) => result.status === "rejected");
+
+    if (failures.length === 0) {
+      notifyCollectionModified();
+      showToastFromConfig(
+        datasetIds.length === 1
+          ? TOAST_MESSAGES.datasetRemovedFromCollection(collectionName)
+          : TOAST_MESSAGES.datasetsRemovedFromCollection(
+              datasetIds.length,
+              collectionName,
+            ),
+      );
+      return;
+    }
+
+    failures.forEach(({ result, datasetId }) => {
+      if (result.status === "rejected") {
+        logError(
+          "Failed to remove dataset from collection (bulk)",
+          result.reason,
+          {
+            collectionId,
+            datasetId,
+          },
+        );
+      }
+    });
+
+    // Revert UI for failed datasets — only their IDs come back
+    const failedIds = new Set(failures.map((f) => f.datasetId));
+    setEditedDatasetIds((current) => {
+      const merged = [...current];
+      for (const id of previousIds) {
+        if (failedIds.has(id) && !merged.includes(id)) merged.push(id);
+      }
+      return merged;
+    });
+    setSelectedDatasets(previousSelection.filter((id) => failedIds.has(id)));
+
+    // Some succeeded — still notify so sidebar refreshes
+    if (failures.length < datasetIds.length) {
+      notifyCollectionModified();
+    }
+    showToastFromConfig(TOAST_MESSAGES.datasetRemoveFailed);
+  };
+
   const handleAddDatasetsFromModal = (newSelectedDatasets: string[]) => {
     // Add any new datasets that aren't already in the collection
     const datasetsToAdd = newSelectedDatasets.filter(
@@ -284,6 +350,7 @@ export default function CustomCollectionPage() {
           onAddToCollection={handleAddToCollection}
           isEditMode={isEditMode}
           onRemoveDataset={isEditMode ? handleRemoveDataset : undefined}
+          onBulkRemoveDatasets={handleBulkRemoveSelectedDatasets}
           customActionButtons={getCustomActionButtons()}
           isCustomCollection={true}
           collectionName={collection.name}

--- a/src/components/Browse/Browse.tsx
+++ b/src/components/Browse/Browse.tsx
@@ -76,6 +76,7 @@ interface BrowseProps {
   isModal?: boolean;
   isEditMode?: boolean;
   onRemoveDataset?: (datasetId: string) => void;
+  onBulkRemoveDatasets?: (datasetIds: string[]) => Promise<void> | void;
   customActionButtons?: Array<{
     label: string;
     icon?: React.ComponentType<{ className?: string }>;
@@ -194,6 +195,7 @@ export default function Browse({
   isModal = false,
   isEditMode = false,
   onRemoveDataset,
+  onBulkRemoveDatasets,
   customActionButtons,
   showAddButton = true, // default true for backward compatibility
   showSearchAndFilters = true, // Default to true
@@ -1032,18 +1034,24 @@ export default function Browse({
                           <Tag className="w-4 h-4 text-icon" />
                           Rename
                         </button>
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            setShowActionsDropdown(false);
-                          }}
-                          className="flex items-center gap-3 w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Trash2 className="w-4 h-4 text-icon" />
-                          Delete
-                        </button>
+                        {onBulkRemoveDatasets && (
+                          <button
+                            type="button"
+                            onClick={async (e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              setShowActionsDropdown(false);
+                              if (currentSelectedDatasets.length === 0) return;
+                              await onBulkRemoveDatasets([
+                                ...currentSelectedDatasets,
+                              ]);
+                            }}
+                            className="flex items-center gap-3 w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-50 transition-colors"
+                          >
+                            <Trash2 className="w-4 h-4 text-icon" />
+                            Delete
+                          </button>
+                        )}
                       </div>
                     )}
                   </div>

--- a/src/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/src/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -19,9 +19,6 @@ interface CreateCollectionModalProps {
   isVisible: boolean;
   onClose: () => void;
   onCreateCollection?: (name: string) => void;
-  onDatasetsAddedToCollections?: (
-    addedCollections: { id: string; name: string }[],
-  ) => void;
   selectedDatasets: string[];
   datasets: Dataset[];
 }
@@ -32,7 +29,6 @@ export default function CreateCollectionModal({
   isVisible,
   onClose,
   onCreateCollection,
-  onDatasetsAddedToCollections,
   selectedDatasets,
   datasets,
 }: CreateCollectionModalProps) {
@@ -133,9 +129,6 @@ export default function CreateCollectionModal({
 
         if (selectedDatasets.length > 0) {
           showDatasetAddedToast([newCollectionName]);
-          onDatasetsAddedToCollections?.([
-            { id: response.id, name: newCollectionName },
-          ]);
         }
 
         if (onCreateCollection) {
@@ -193,7 +186,6 @@ export default function CreateCollectionModal({
       // Also notify that collections have been modified to refresh sidebar
       notifyCollectionModified();
       showDatasetAddedToast(targetCollections.map((c) => c.name));
-      onDatasetsAddedToCollections?.(targetCollections);
     } catch (error) {
       logError("Failed to add datasets to collections", error);
       alert("Failed to add datasets to collections. Please try again.");

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.tsx
@@ -1,33 +1,25 @@
 "use client";
 
 import { Button } from "@ui/Button";
-import { Box, Plus, X } from "lucide-react";
+import { Chip } from "@ui/Chip";
+import { Box, Plus } from "lucide-react";
 import styles from "./DatasetSidebarSection.module.scss";
 
-export interface SidebarCollectionRef {
-  id: string;
-  name: string;
-}
-
 interface DatasetCollectionSectionProps {
-  collections: SidebarCollectionRef[];
+  displayCategory: string;
   onAddClick: () => void;
-  onRemove: (collection: SidebarCollectionRef) => void;
-  isRemoving?: (collectionId: string) => boolean;
 }
 
 export default function DatasetCollectionSection({
-  collections,
+  displayCategory,
   onAddClick,
-  onRemove,
-  isRemoving,
 }: DatasetCollectionSectionProps) {
   return (
     <div className={styles.datasetSidebarSection}>
       <div className={styles.datasetSidebarSection__header}>
         <div className={styles.datasetSidebarSection__headerLeft}>
           <Box className={styles.datasetSidebarSection__icon} />
-          <h3 className={styles.datasetSidebarSection__title}>Collections</h3>
+          <h3 className={styles.datasetSidebarSection__title}>Collection</h3>
         </div>
         <Button
           variant="outline"
@@ -39,39 +31,10 @@ export default function DatasetCollectionSection({
           Add
         </Button>
       </div>
-      {collections.length > 0 ? (
-        <div className={styles.datasetSidebarSection__chips}>
-          {collections.map((collection) => {
-            const removing = isRemoving?.(collection.id) ?? false;
-            return (
-              <span
-                key={collection.id}
-                className={styles.datasetSidebarSection__chipWithRemove}
-                data-testid={`collection-chip-${collection.id}`}
-              >
-                <span
-                  className={styles.datasetSidebarSection__chipLabel}
-                  title={collection.name}
-                >
-                  {collection.name}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => onRemove(collection)}
-                  disabled={removing}
-                  aria-label={`Remove dataset from ${collection.name}`}
-                  className={styles.datasetSidebarSection__chipRemoveBtn}
-                >
-                  <X className={styles.datasetSidebarSection__chipRemoveIcon} />
-                </button>
-              </span>
-            );
-          })}
-        </div>
-      ) : (
-        <span className={styles.datasetSidebarSection__emptyText}>
-          Not in any collection yet.
-        </span>
+      {displayCategory && (
+        <Chip color="grey" variant="regular" size="sm">
+          {displayCategory}
+        </Chip>
       )}
     </div>
   );

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetSidebar.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetSidebar.tsx
@@ -1,17 +1,10 @@
 "use client";
 
-import { Toast } from "@ui/Toast";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import CreateCollectionModal from "@/components/CreateCollectionModal";
-import { TOAST_MESSAGES } from "@/constants/toastMessages.mjs";
-import { useCollections } from "@/contexts/CollectionsContext";
 import type { Dataset, DatasetPlus } from "@/data/dataset";
-import { useApi } from "@/hooks/useApi";
-import { logError } from "@/lib/logger";
 import DatasetCitationSection from "./DatasetCitationSection";
-import DatasetCollectionSection, {
-  type SidebarCollectionRef,
-} from "./DatasetCollectionSection";
+import DatasetCollectionSection from "./DatasetCollectionSection";
 import DatasetCountrySection from "./DatasetCountrySection";
 import DatasetLanguageSection from "./DatasetLanguageSection";
 import DatasetLicenseSection from "./DatasetLicenseSection";
@@ -33,7 +26,7 @@ interface DatasetSidebarProps {
 
 export default function DatasetSidebar({
   dataset,
-  displayCategory: _displayCategory,
+  displayCategory,
   displayAccess,
   permissions,
   hasBrowsePermission,
@@ -41,97 +34,14 @@ export default function DatasetSidebar({
   hasDownloadPermission,
   hasManagePermission,
 }: DatasetSidebarProps) {
-  const api = useApi();
-  const { notifyCollectionModified } = useCollections();
   const [showCreateCollectionModal, setShowCreateCollectionModal] =
     useState(false);
-
-  const initialCollections = useMemo<SidebarCollectionRef[]>(
-    () => (dataset.collections ?? []).map((c) => ({ id: c.id, name: c.name })),
-    [dataset.collections],
-  );
-
-  const [collections, setCollections] =
-    useState<SidebarCollectionRef[]>(initialCollections);
-  const [removingIds, setRemovingIds] = useState<Set<string>>(new Set());
-
-  useEffect(() => {
-    setCollections(initialCollections);
-  }, [initialCollections]);
-
-  const [showToast, setShowToast] = useState(false);
-  const [toastMessage, setToastMessage] = useState("");
-  const [toastType, setToastType] = useState<"success" | "error">("success");
-
-  const showToastFromConfig = useCallback(
-    (config: { message: string; type: "success" | "error" }) => {
-      setToastType(config.type);
-      setToastMessage(config.message);
-      setShowToast(true);
-    },
-    [],
-  );
-
-  const handleAddedToCollections = useCallback(
-    (added: { id: string; name: string }[]) => {
-      setCollections((prev) => {
-        const existingIds = new Set(prev.map((c) => c.id));
-        const toAdd = added.filter((c) => !existingIds.has(c.id));
-        return [...prev, ...toAdd];
-      });
-    },
-    [],
-  );
-
-  const handleRemoveCollection = useCallback(
-    async (collection: SidebarCollectionRef) => {
-      if (!dataset.id) return;
-      const previous = collections;
-      setCollections((prev) => prev.filter((c) => c.id !== collection.id));
-      setRemovingIds((prev) => new Set(prev).add(collection.id));
-
-      try {
-        await api.removeDatasetFromUserCollection(collection.id, dataset.id);
-        notifyCollectionModified();
-        showToastFromConfig(
-          TOAST_MESSAGES.datasetRemovedFromCollection(collection.name),
-        );
-      } catch (error) {
-        logError("Failed to remove dataset from collection", error, {
-          collectionId: collection.id,
-          datasetId: dataset.id,
-        });
-        setCollections(previous);
-        showToastFromConfig(TOAST_MESSAGES.datasetRemoveFailed);
-      } finally {
-        setRemovingIds((prev) => {
-          const next = new Set(prev);
-          next.delete(collection.id);
-          return next;
-        });
-      }
-    },
-    [
-      api,
-      collections,
-      dataset.id,
-      notifyCollectionModified,
-      showToastFromConfig,
-    ],
-  );
-
-  const isRemoving = useCallback(
-    (collectionId: string) => removingIds.has(collectionId),
-    [removingIds],
-  );
 
   return (
     <div className={styles.datasetSidebar}>
       <DatasetCollectionSection
-        collections={collections}
+        displayCategory={displayCategory}
         onAddClick={() => setShowCreateCollectionModal(true)}
-        onRemove={handleRemoveCollection}
-        isRemoving={isRemoving}
       />
 
       <DatasetPermissionsSection
@@ -163,14 +73,6 @@ export default function DatasetSidebar({
         onClose={() => setShowCreateCollectionModal(false)}
         selectedDatasets={dataset.id ? [dataset.id] : []}
         datasets={[dataset as Dataset]}
-        onDatasetsAddedToCollections={handleAddedToCollections}
-      />
-
-      <Toast
-        message={toastMessage}
-        isVisible={showToast}
-        onClose={() => setShowToast(false)}
-        type={toastType}
       />
     </div>
   );

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetSidebarSection.module.scss
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetSidebarSection.module.scss
@@ -54,66 +54,6 @@
     gap: $spacing-sm;
   }
 
-  &__chipWithRemove {
-    display: inline-flex;
-    align-items: center;
-    gap: $spacing-xs;
-    background: $color-background-secondary;
-    border: 1px solid $color-border;
-    @include border-radius-sm;
-    padding: 2px $spacing-sm;
-    max-width: 100%;
-  }
-
-  &__chipLabel {
-    @include font-base;
-    @include text-base;
-    @include text-primary;
-    line-height: 1.5;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 200px;
-  }
-
-  &__chipRemoveBtn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border: none;
-    background: transparent;
-    padding: 2px;
-    cursor: pointer;
-    color: inherit;
-    border-radius: 50%;
-
-    &:hover:not(:disabled) {
-      background: rgba(0, 0, 0, 0.06);
-    }
-
-    &:disabled {
-      opacity: 0.4;
-      cursor: not-allowed;
-    }
-
-    &:focus-visible {
-      outline: 2px solid currentColor;
-      outline-offset: 1px;
-    }
-  }
-
-  &__chipRemoveIcon {
-    width: 14px;
-    height: 14px;
-  }
-
-  &__emptyText {
-    @include font-base;
-    @include text-base;
-    line-height: 1.5;
-    color: rgba(0, 0, 0, 0.5);
-  }
-
   &__link {
     @include font-base;
     @include text-base;

--- a/src/constants/toastMessages.d.mts
+++ b/src/constants/toastMessages.d.mts
@@ -14,6 +14,10 @@ export const TOAST_MESSAGES: {
   readonly datasetRemovedFromCollection: (
     collectionName?: string,
   ) => ToastConfig;
+  readonly datasetsRemovedFromCollection: (
+    count: number,
+    collectionName?: string,
+  ) => ToastConfig;
   readonly datasetRemoveFailed: ToastConfig;
   readonly collectionDeleted: ToastConfig;
   readonly collectionDeleteFailed: ToastConfig;

--- a/src/constants/toastMessages.mjs
+++ b/src/constants/toastMessages.mjs
@@ -17,6 +17,12 @@ export const TOAST_MESSAGES = {
       : "Dataset removed from collection.",
     type: "success",
   }),
+  datasetsRemovedFromCollection: (count, collectionName) => ({
+    message: collectionName
+      ? `${count} datasets removed from ${collectionName}.`
+      : `${count} datasets removed from collection.`,
+    type: "success",
+  }),
   datasetRemoveFailed: {
     message: "Failed to remove dataset from collection. Please try again.",
     type: "error",


### PR DESCRIPTION
Refs #160 — *intentionally NOT auto-closing*. Issue stays open for manual QA.

## Why

Follow-up on #160 review: the Delete-from-collection action landed in the **wrong context** in PR #174 — X icons on collection chips in the DatasetSidebar (right Properties panel) of the dataset details page. The reviewer pointed out the correct location is the **selection-level 3-dots dropdown inside the custom collection view**, accessed by clicking Select on a dataset tile.

The dropdown's Delete button in `Browse.tsx` was a complete no-op:

\`\`\`jsx
<button onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowActionsDropdown(false); }}>
  <Trash2 ... /> Delete
</button>
\`\`\`

## What changed

### Revert (wrong-context Delete from PR #174)

| File | Change |
|---|---|
| `DatasetCollectionSection.tsx` | Back to original single \`displayCategory\` Chip + Add button |
| `DatasetSidebar.tsx` | Dropped \`localCollections\` state, \`handleRemoveCollection\`, \`removingIds\`, sidebar-side Toast. Restored \`displayCategory\` usage. Kept \`CreateCollectionModal\` swap. |
| `DatasetSidebarSection.module.scss` | Removed \`__chipWithRemove\`, \`__chipLabel\`, \`__chipRemoveBtn\`, \`__chipRemoveIcon\`, \`__emptyText\` (unused now) |
| `CreateCollectionModal.tsx` | Removed the unused \`onDatasetsAddedToCollections\` callback |

### Kept (still useful)

- \`CreateCollectionModal\` is still used in the sidebar (the Add to collection flow Ella confirmed works).
- Toast helpers with named/multi variants from PR #174.
- \`handleRemoveDataset\` in custom collection page (used by per-row X in edit mode, separate from the 3-dots Delete).

### New — wire the actual fix

| File | Change |
|---|---|
| \`Browse.tsx\` | New optional prop \`onBulkRemoveDatasets?: (ids: string[]) => Promise<void> \| void\`. Selection-dropdown Delete button now calls it with \`currentSelectedDatasets\` and is *hidden* entirely when the prop isn't passed (no more dead Delete on \`/browse\` outside a collection). |
| \`custom/[id]/page.tsx\` | New \`handleBulkRemoveSelectedDatasets\` — optimistic removal from the edit list and from the selection, parallel \`Promise.allSettled\` of \`api.removeDatasetFromUserCollection\`, partial-failure recovery (reverts only failed IDs), single summary toast (success or error). Wired into \`<Browse onBulkRemoveDatasets={...} />\`. |
| \`toastMessages.mjs\` (+ \`.d.mts\`) | New \`datasetsRemovedFromCollection(count, name)\` helper for the bulk case. |

## Local verification

- [x] Biome — clean (305 files)
- [x] TypeScript — clean
- [x] Tests — 79/79 pass
- [x] Build — succeeded

## Test plan (per Ella's repro)

1. Navigate to \`/browse\`.
2. Add a dataset to a collection (new or existing — e.g. "11.05 collection ES").
3. Open that collection from the left sidebar.
4. Click **Select** on a dataset tile.
5. Click the **3 dots** icon in the top-right (selection-level dropdown).
6. Click **Delete**.
   - Expected: dataset disappears from the list, success toast appears.
   - Refresh: dataset really gone from the collection.
7. Repeat with 2+ selected datasets — toast: \`"N datasets removed from {name}."\`
8. Network-offline test (DevTools): selected items reappear, error toast.

## Out of scope

- The title-level dropdown's stand-alone "Delete" button (separate from "Delete Collection") still does nothing. The reviewer's comment only addresses the selection-level dropdown. Left as-is.
- \`/browse\` outside a collection no longer renders the dropdown's Delete option at all — the prop is undefined there. If a future feature wants bulk-delete from \`/browse\`, it can pass \`onBulkRemoveDatasets\`.