### PR TITLE
fix: unblock docker build — pin pnpm and set CI=true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
+        # Version is sourced from the `packageManager` field in package.json
+        # to avoid the "Multiple versions of pnpm specified" error.
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/code-metrics.yml
+++ b/.github/workflows/code-metrics.yml
@@ -29,9 +29,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
+        # Version is sourced from `packageManager` in package.json.
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,9 +34,8 @@ jobs:
           queries: +security-and-quality
 
       - name: Setup pnpm
+        # Version is sourced from `packageManager` in package.json.
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ ARG NEXT_PUBLIC_BASE_PATH=""
 ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
 
 ENV NODE_OPTIONS="--max-old-space-size=4096"
+# CI=true tells pnpm that this is a non-interactive environment;
+# without it pnpm aborts on no-TTY when it wants to purge stale
+# node_modules (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
+ENV CI=true
 RUN pnpm run build
 
 # Production image, copy all the files and run next

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "data-gems-frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=10.0.0"


### PR DESCRIPTION
## Summary

Docker build on the deploy host fails with:

\`\`\`
ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY
Aborted removal of modules directory due to no TTY

If you are running pnpm in CI, set the CI environment variable to "true",
or set "confirmModulesPurge" to "false".
\`\`\`

Corepack updated its default pnpm to **11.1.0** on this host (we'd been on 10.x). The new pnpm sees \`node_modules\` (carried in via \`COPY --from=deps\` in the Dockerfile) as stale compared to the lockfile, decides to purge them, and aborts because the docker build runs without a TTY.

## Fix

**Dockerfile** — \`ENV CI=true\` before \`pnpm run build\`. Tells pnpm to treat the run as non-interactive and proceed.

**package.json** — pin \`"packageManager": "pnpm@10.33.0"\`. Corepack honors this field exactly, so future Corepack default changes can't silently bump us to a new pnpm major. Matches the version CI is already using (pnpm/action-setup@v4 with \`version: 10\`).

## Local verification

- [x] \`pnpm --version\` → \`10.33.0\` (Corepack picks the pinned version)
- [x] \`pnpm run lint:biome:check\` — clean
- [x] \`pnpm run type-check\` — clean
- [x] \`pnpm test\` — 79/79 pass
- [x] \`pnpm run build\` — succeeded

## Test plan after merge

On the deploy host:
- [ ] \`git pull\`
- [ ] \`docker compose up -d --build\` — no more \`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY\`; build completes
- [ ] \`docker compose ps\` — container Up and healthy after ~40 s start period