### PR TITLE
feat(DG-176): adjust dataset onboarding form fields

### DIFF
--- a/src/components/AddDatasetForm/AddDatasetForm.tsx
+++ b/src/components/AddDatasetForm/AddDatasetForm.tsx
@@ -29,12 +29,13 @@ interface FormData {
     headline: string;
     description: string;
     keywords: string[];
-    authors: string;
   };
   classification: {
     fieldsOfScience: string[];
     collection: string;
     license: string;
+    languages: string[];
+    countries: string[];
   };
   additionalInfo: {
     referenceString: string;
@@ -49,12 +50,13 @@ interface FormErrors {
     headline?: string;
     description?: string;
     keywords?: string;
-    authors?: string;
   };
   classification: {
     fieldsOfScience?: string;
     collection?: string;
     license?: string;
+    languages?: string;
+    countries?: string;
   };
   additionalInfo: {
     referenceString?: string;
@@ -69,12 +71,13 @@ const initialFormData: FormData = {
     headline: "",
     description: "",
     keywords: [],
-    authors: "",
   },
   classification: {
     fieldsOfScience: [],
     collection: "",
     license: "",
+    languages: [],
+    countries: [],
   },
   additionalInfo: {
     referenceString: "",
@@ -87,8 +90,6 @@ const initialErrors: FormErrors = {
   classification: {},
   additionalInfo: {},
 };
-
-const AUTHORS_MAX_LENGTH = 250;
 
 // data-flows.md: staged files use Kind 0 (File) with the path returned by upload.
 // Backend expects /storage/datagems/gw/dataset_upload\<filename> format (Postman).
@@ -309,7 +310,6 @@ export default function AddDatasetForm() {
             headline: headline || name,
             description,
             keywords,
-            authors: prev.basicInfo.authors,
           },
           classification: {
             ...prev.classification,
@@ -362,10 +362,6 @@ export default function AddDatasetForm() {
         "Description must be 3000 characters or less";
     }
 
-    if (formData.basicInfo.authors.length > AUTHORS_MAX_LENGTH) {
-      newErrors.basicInfo.authors = `Authors must be ${AUTHORS_MAX_LENGTH} characters or less`;
-    }
-
     // Validate keywords: required and max combined length 250
     const combinedKeywords = formData.basicInfo.keywords
       .filter(Boolean)
@@ -385,17 +381,15 @@ export default function AddDatasetForm() {
       newErrors.classification.license = "License is required";
     }
 
-    if (!formData.additionalInfo.referenceString.trim()) {
-      newErrors.additionalInfo.referenceString =
-        "Reference string (citation) is required";
-    } else if (formData.additionalInfo.referenceString.length > 3000) {
+    if (formData.additionalInfo.referenceString.length > 3000) {
       newErrors.additionalInfo.referenceString =
         "Reference string must be 3000 characters or less";
     }
 
-    if (!formData.additionalInfo.sourceLink.trim()) {
-      newErrors.additionalInfo.sourceLink = "Dataset source URL is required";
-    } else if (!isValidUrl(formData.additionalInfo.sourceLink)) {
+    if (
+      formData.additionalInfo.sourceLink.trim() &&
+      !isValidUrl(formData.additionalInfo.sourceLink)
+    ) {
       newErrors.additionalInfo.sourceLink = "Please enter a valid URL";
     }
 
@@ -485,8 +479,8 @@ export default function AddDatasetForm() {
         headline: formData.basicInfo.headline,
         keywords: formData.basicInfo.keywords,
         fieldOfScience: formData.classification.fieldsOfScience,
-        language: [],
-        country: [],
+        language: formData.classification.languages,
+        country: formData.classification.countries,
         datePublished: new Date().toISOString().split("T")[0],
         citeAs: formData.additionalInfo.referenceString.trim(),
         conformsTo: "https://schema.org/Dataset",

--- a/src/components/ui/datasets/AdditionalInformation.tsx
+++ b/src/components/ui/datasets/AdditionalInformation.tsx
@@ -37,7 +37,6 @@ export function AdditionalInformation({
       <div>
         <Textarea
           label="Reference String (Citation)"
-          required
           value={data.referenceString}
           onChange={(e) => handleFieldChange("referenceString", e.target.value)}
           placeholder="How should this dataset be cited?"
@@ -52,7 +51,6 @@ export function AdditionalInformation({
 
       <Input
         label="Dataset Source Link"
-        required
         value={data.sourceLink}
         onChange={(e) => handleFieldChange("sourceLink", e.target.value)}
         placeholder="https://..."

--- a/src/components/ui/datasets/BasicInformation.test.tsx
+++ b/src/components/ui/datasets/BasicInformation.test.tsx
@@ -7,7 +7,6 @@ type BasicInformationData = {
   headline: string;
   description: string;
   keywords: string[];
-  authors: string;
 };
 
 const initialData: BasicInformationData = {
@@ -15,23 +14,9 @@ const initialData: BasicInformationData = {
   headline: "",
   description: "",
   keywords: [],
-  authors: "",
 };
 
 describe("BasicInformation", () => {
-  it("renders authors field with counter and max length", () => {
-    render(
-      <BasicInformation data={initialData} onChange={() => {}} errors={{}} />,
-    );
-
-    expect(screen.getByPlaceholderText("Enter authors")).toBeInTheDocument();
-    expect(screen.getAllByText("0/250").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByPlaceholderText("Enter authors")).toHaveAttribute(
-      "maxLength",
-      "250",
-    );
-  });
-
   it("renders all basic info fields", () => {
     render(
       <BasicInformation data={initialData} onChange={() => {}} errors={{}} />,
@@ -48,8 +33,14 @@ describe("BasicInformation", () => {
         "Provide a detailed description of the dataset contents",
       ).length,
     ).toBeGreaterThanOrEqual(1);
-    expect(
-      screen.getAllByPlaceholderText("Enter authors").length,
-    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not render an Authors field", () => {
+    render(
+      <BasicInformation data={initialData} onChange={() => {}} errors={{}} />,
+    );
+
+    expect(screen.queryByPlaceholderText("Enter authors")).toBeNull();
+    expect(screen.queryByText(/^Authors$/)).toBeNull();
   });
 });

--- a/src/components/ui/datasets/BasicInformation.tsx
+++ b/src/components/ui/datasets/BasicInformation.tsx
@@ -9,7 +9,6 @@ interface BasicInformationData {
   headline: string;
   description: string;
   keywords: string[];
-  authors: string;
 }
 
 interface BasicInformationProps {
@@ -20,11 +19,8 @@ interface BasicInformationProps {
     headline?: string;
     description?: string;
     keywords?: string;
-    authors?: string;
   };
 }
-
-const AUTHORS_MAX_LENGTH = 250;
 
 export function BasicInformation({
   data,
@@ -89,20 +85,6 @@ export function BasicInformation({
         required={true}
         maxLength={250}
       />
-
-      <div>
-        <Input
-          label="Authors"
-          value={data.authors}
-          onChange={(e) => handleFieldChange("authors", e.target.value)}
-          placeholder="Enter authors"
-          error={errors.authors}
-          maxLength={AUTHORS_MAX_LENGTH}
-        />
-        <div className="mt-1 text-xs text-gray-650 text-right">
-          {data.authors.length}/{AUTHORS_MAX_LENGTH}
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/components/ui/datasets/Classification.tsx
+++ b/src/components/ui/datasets/Classification.tsx
@@ -21,12 +21,15 @@ import HierarchicalDropdown, {
 } from "../HierarchicalDropdown";
 import { Input } from "../Input";
 import { Select } from "../Select";
+import { KeywordInput } from "./KeywordInput";
 import { LicenseCard } from "./LicenseCard";
 
 interface ClassificationData {
   fieldsOfScience: string[];
   collection: string;
   license: string;
+  languages: string[];
+  countries: string[];
 }
 
 interface ClassificationProps {
@@ -36,6 +39,8 @@ interface ClassificationProps {
     fieldsOfScience?: string;
     collection?: string;
     license?: string;
+    languages?: string;
+    countries?: string;
   };
 }
 
@@ -327,6 +332,24 @@ export function Classification({
           )
         )}
       </div>
+
+      <KeywordInput
+        label="Languages"
+        value={data.languages}
+        onChange={(languages) => handleFieldChange("languages", languages)}
+        placeholder="Enter language codes separate with commas e.g. en, de, fr"
+        error={errors.languages}
+        required={false}
+      />
+
+      <KeywordInput
+        label="Country"
+        value={data.countries}
+        onChange={(countries) => handleFieldChange("countries", countries)}
+        placeholder="Enter country-code separate with commas e.g. US, DE, IT"
+        error={errors.countries}
+        required={false}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Refs #176 — intentionally not auto-closing. Issue stays open for manual QA.

## Summary

Three form-field adjustments on \`/datasets/add\`:

1. **Authors field removed** from the Basic Information section.
2. **Languages & Country** tag-style fields added to the Classification box, immediately after License. Optional, reuse the existing \`KeywordInput\` component (same blue-chip-with-X styling that Keywords already uses). Wired into the existing-but-previously-hardcoded \`language\`/\`country\` arrays in the onboard API payload.
3. **Reference String (Citation)** and **Dataset Source Link** are now optional — red asterisks removed and "is required" validations dropped. Format/length checks (max 3000 chars for citation, valid-URL check for source link) are kept, but only applied when the field is non-empty.

## What changed

| File | Change |
|---|---|
| \`BasicInformation.tsx\` | Removed Authors \`<Input>\`, its types in \`BasicInformationData\` / errors, and the character counter |
| \`BasicInformation.test.tsx\` | Removed the Authors-specific render test, dropped \`authors\` from the mock data, added a negative assertion that the field is gone |
| \`Classification.tsx\` | Added \`languages: string[]\` and \`countries: string[]\` to \`ClassificationData\`; added two \`<KeywordInput>\` instances after the License block; new import of \`KeywordInput\` |
| \`AdditionalInformation.tsx\` | Dropped \`required\` from both \`<Textarea>\` (Reference String) and \`<Input>\` (Source Link) |
| \`AddDatasetForm.tsx\` | Schema cleanup (drop \`authors\`, add \`languages\` / \`countries\`); removed \`AUTHORS_MAX_LENGTH\` constant and Authors validation; loosened citation/sourceLink validation to format-only; wired the new fields into the onboard API payload (\`language: formData.classification.languages\`, \`country: formData.classification.countries\`, replacing the hardcoded \`[]\`) |

## Local verification

- [x] Biome — clean (305 files)
- [x] TypeScript — clean
- [x] \`pnpm test\` (the gauntlet CI runs) — 79/79 pass
- [x] \`pnpm run build\` — succeeded

## Test plan (manual, per Ella's repro)

1. Navigate to \`/datasets/add\`.
2. Verify Basic Information section no longer shows an Authors field.
3. Submit a dataset without filling Reference String or Dataset Source Link — should be allowed (no red asterisks, no "required" errors).
4. Fill in a few keywords for Languages (e.g. \`en, de, fr\`) — blue chips with X should appear, identical styling to Keywords.
5. Fill in country codes for Country (e.g. \`US, DE, IT\`) — same chip behavior.
6. Submit. Inspect Network request for \`/api/dataset/onboard\` — payload should contain \`language: ["en","de","fr"]\` and \`country: ["US","DE","IT"]\`, not \`[]\`.
7. Round-trip: edit the same dataset via \`?datasetId=...\` — fields should re-populate (note: existing edit-mode loader doesn't yet hydrate languages/countries because the API field-projection currently doesn't ask for them; out of scope for this PR).

## Out of scope

- The \`?datasetId=\` edit-mode loader does not currently re-populate languages/countries from the loaded dataset. That requires asking the API for those fields in the projection — separate concern (and unrelated to this PR's UI changes). Flagged for follow-up.
- No format validation on language/country codes (e.g. \`xx\` is accepted). Spec doesn't require it; backend will validate if needed.