### PR TITLE
DG-188 | Weather pilot workspace

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -96,12 +96,16 @@ export interface ConversationMessage {
 interface ChatPageProps {
   showConversationName?: boolean;
   hideCollectionActions?: boolean;
+  withLayout?: boolean;
+  forcedCollectionId?: string | null;
 }
 
 // Main chat component that uses useSearchParams
-function ChatPageContent({
+export function ChatPageContent({
   showConversationName,
   hideCollectionActions,
+  withLayout = true,
+  forcedCollectionId,
 }: ChatPageProps) {
   const [selectedDatasets, setSelectedDatasets] = useState<string[]>([]);
   const api = useApi();
@@ -124,11 +128,15 @@ function ChatPageContent({
   }, []);
 
   useEffect(() => {
+    if (forcedCollectionId !== undefined) {
+      setInitialCollectionId(forcedCollectionId);
+      return;
+    }
     const collectionId = searchParams?.get("collection");
     if (collectionId !== initialCollectionId) {
       setInitialCollectionId(collectionId);
     }
-  }, [searchParams, initialCollectionId]);
+  }, [searchParams, initialCollectionId, forcedCollectionId]);
 
   useEffect(() => {
     if (!isMounted || !api.hasToken) return;
@@ -311,22 +319,28 @@ function ChatPageContent({
     });
   }
 
+  const chat = (
+    <Chat
+      selectedDatasets={selectedDatasets}
+      datasets={normalizeDatasets(datasets) as Dataset[]}
+      onSelectedDatasetsChange={(datasets) => {
+        setSelectedDatasets(datasets);
+      }}
+      conversationId={conversationId}
+      initialMessages={chatInitialMessages ?? undefined}
+      showConversationName={showConversationName}
+      hideCollectionActions={hideCollectionActions}
+      initialCollectionId={initialCollectionId}
+    />
+  );
+
+  if (!withLayout) {
+    return <ProtectedPage>{chat}</ProtectedPage>;
+  }
+
   return (
     <ProtectedPage>
-      <DashboardLayout>
-        <Chat
-          selectedDatasets={selectedDatasets}
-          datasets={normalizeDatasets(datasets) as Dataset[]}
-          onSelectedDatasetsChange={(datasets) => {
-            setSelectedDatasets(datasets);
-          }}
-          conversationId={conversationId}
-          initialMessages={chatInitialMessages ?? undefined}
-          showConversationName={showConversationName}
-          hideCollectionActions={hideCollectionActions}
-          initialCollectionId={initialCollectionId}
-        />
-      </DashboardLayout>
+      <DashboardLayout>{chat}</DashboardLayout>
     </ProtectedPage>
   );
 }
@@ -334,12 +348,16 @@ function ChatPageContent({
 export default function ChatPage({
   showConversationName = true,
   hideCollectionActions = false,
+  withLayout = true,
+  forcedCollectionId,
 }: ChatPageProps) {
   return (
     <Suspense fallback={<div>Loading...</div>}>
       <ChatPageContent
         showConversationName={showConversationName}
         hideCollectionActions={hideCollectionActions}
+        withLayout={withLayout}
+        forcedCollectionId={forcedCollectionId}
       />
     </Suspense>
   );

--- a/src/app/use-case/UseCasePageClient.tsx
+++ b/src/app/use-case/UseCasePageClient.tsx
@@ -85,12 +85,14 @@ interface UseCasePageClientProps {
   collectionName: string;
   title: string;
   subtitle: string;
+  withLayout?: boolean;
 }
 
 export default function UseCasePageClient({
   collectionName,
   title,
   subtitle,
+  withLayout = true,
 }: UseCasePageClientProps) {
   const api = useApi();
   const router = useRouter();
@@ -328,38 +330,40 @@ export default function UseCasePageClient({
     setShowCreateCollectionModal(true);
   }, [selectedDatasets]);
 
-  return (
-    <DashboardLayout>
-      <div className="relative p-6">
-        <Browse
-          datasets={displayedDatasets}
-          title={title}
-          subtitle={subtitle}
-          showSelectAll={true}
-          showSearchAndFilters={true}
-          searchTerm={pendingSearchTerm}
-          onSearchTermChange={handleSearchTermChange}
-          onSearchTermSubmit={handleSearchTermSubmit}
-          isSmartSearchEnabled={isSmartSearchEnabled}
-          onSmartSearchToggle={setIsSmartSearchEnabled}
-          selectedDatasets={selectedDatasets}
-          onSelectedDatasetsChange={setSelectedDatasets}
-          showSelectedPanel={showSelectedPanel}
-          onCloseSidebar={() => setShowSelectedPanel(false)}
-          onReopenSidebar={() => setShowSelectedPanel(true)}
-          onChatWithData={handleChatWithData}
-          onAddToCollection={handleAddToCollection}
-          isLoading={isLoading}
-          error={error}
-        />
+  const content = (
+    <div className="relative p-6">
+      <Browse
+        datasets={displayedDatasets}
+        title={title}
+        subtitle={subtitle}
+        showSelectAll={true}
+        showSearchAndFilters={true}
+        searchTerm={pendingSearchTerm}
+        onSearchTermChange={handleSearchTermChange}
+        onSearchTermSubmit={handleSearchTermSubmit}
+        isSmartSearchEnabled={isSmartSearchEnabled}
+        onSmartSearchToggle={setIsSmartSearchEnabled}
+        selectedDatasets={selectedDatasets}
+        onSelectedDatasetsChange={setSelectedDatasets}
+        showSelectedPanel={showSelectedPanel}
+        onCloseSidebar={() => setShowSelectedPanel(false)}
+        onReopenSidebar={() => setShowSelectedPanel(true)}
+        onChatWithData={handleChatWithData}
+        onAddToCollection={handleAddToCollection}
+        isLoading={isLoading}
+        error={error}
+      />
 
-        <CreateCollectionModal
-          isVisible={showCreateCollectionModal}
-          onClose={() => setShowCreateCollectionModal(false)}
-          selectedDatasets={selectedDatasets}
-          datasets={allDatasets}
-        />
-      </div>
-    </DashboardLayout>
+      <CreateCollectionModal
+        isVisible={showCreateCollectionModal}
+        onClose={() => setShowCreateCollectionModal(false)}
+        selectedDatasets={selectedDatasets}
+        datasets={allDatasets}
+      />
+    </div>
   );
+
+  if (!withLayout) return content;
+
+  return <DashboardLayout>{content}</DashboardLayout>;
 }

--- a/src/app/use-case/weather/WeatherTabBar.tsx
+++ b/src/app/use-case/weather/WeatherTabBar.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Database, House, MessageCircle } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const TABS = [
+  { label: "Home", href: "/use-case/weather/home", Icon: House },
+  { label: "Chat", href: "/use-case/weather/chat", Icon: MessageCircle },
+  { label: "Datasets", href: "/use-case/weather/datasets", Icon: Database },
+] as const;
+
+export default function WeatherTabBar() {
+  const pathname = usePathname();
+
+  return (
+    <div className="bg-white border-b border-[#e2e8f0] flex h-14 items-start justify-center px-5 w-full shrink-0">
+      <div className="flex gap-4 items-center w-full max-w-[900px]">
+        {TABS.map(({ label, href, Icon }) => {
+          const isActive = pathname === href;
+          return (
+            <Link
+              key={href}
+              href={href}
+              className="relative flex h-[55px] items-end justify-center"
+            >
+              <div className="flex gap-1.5 items-center h-full justify-center px-2">
+                <Icon
+                  size={16}
+                  className={isActive ? "text-[#2b7fff]" : "text-[#5b708f]"}
+                />
+                <span
+                  className={`text-base font-medium leading-[1.5] whitespace-nowrap ${
+                    isActive ? "text-[#314158]" : "text-[#5b708f]"
+                  }`}
+                >
+                  {label}
+                </span>
+              </div>
+              {isActive && (
+                <div className="absolute bottom-0 left-0 right-0 h-[3px] bg-[#2b7fff] rounded-tl-sm rounded-tr-sm" />
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/use-case/weather/chat/page.tsx
+++ b/src/app/use-case/weather/chat/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Suspense } from "react";
+import { ChatPageContent } from "@/app/chat/page";
+import { useCollections } from "@/contexts/CollectionsContext";
+
+function WeatherChatInner() {
+  const { collections } = useCollections();
+  const weatherCollection = collections.find(
+    (c) => c.name?.toLowerCase().trim() === "meteo",
+  );
+
+  return (
+    <ChatPageContent
+      withLayout={false}
+      forcedCollectionId={weatherCollection?.id ?? null}
+      showConversationName={false}
+      hideCollectionActions={true}
+    />
+  );
+}
+
+export default function WeatherChatPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <WeatherChatInner />
+    </Suspense>
+  );
+}

--- a/src/app/use-case/weather/datasets/page.tsx
+++ b/src/app/use-case/weather/datasets/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import UseCasePageClient from "../../UseCasePageClient";
+
+export default function WeatherDatasetsPage() {
+  return (
+    <UseCasePageClient
+      collectionName="Weather"
+      title="Weather Datasets"
+      subtitle="Weather dataset collection"
+      withLayout={false}
+    />
+  );
+}

--- a/src/app/use-case/weather/home/page.tsx
+++ b/src/app/use-case/weather/home/page.tsx
@@ -1,0 +1,108 @@
+import { ArrowRight, Search } from "lucide-react";
+import Link from "next/link";
+
+export default function WeatherHomePage() {
+  return (
+    <div className="flex justify-center px-5 py-10">
+      <div className="flex flex-col gap-6 w-full max-w-[900px]">
+        {/* Hero */}
+        <div className="flex flex-col gap-2">
+          <h1 className="text-[32px] font-semibold text-[#314158] leading-[1.4]">
+            Explore Weather data with AI
+          </h1>
+          <p className="text-[20px] font-normal text-[#5b708f] leading-[1.4]">
+            Ask questions in natural language get answers from real data
+          </p>
+        </div>
+
+        {/* Start Research card */}
+        <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-6 justify-between">
+          <div className="flex flex-col gap-6">
+            <div className="bg-[#f5f9ff] rounded-lg p-2 w-10 h-10 flex items-center justify-center">
+              <Search size={20} className="text-[#2b7fff]" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <h2 className="text-[20px] font-semibold text-[#314158] leading-[1.4]">
+                Start Your Research
+              </h2>
+              <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                Get reliable answers grounded in real weather data.
+                <br />
+                Explore patterns, trends, and evidence across trusted datasets.
+              </p>
+            </div>
+          </div>
+          <Link
+            href="/use-case/weather/chat"
+            className="inline-flex items-center gap-2 bg-[#052f4a] text-white text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] w-fit shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)]"
+          >
+            Start Research
+            <ArrowRight size={16} />
+          </Link>
+        </div>
+
+        {/* How it works */}
+        <div className="flex flex-col gap-4">
+          <h3 className="text-[16px] font-semibold text-[#314158] leading-[1.5]">
+            How it works?
+          </h3>
+          <div className="grid grid-cols-3 gap-4">
+            {/* Step 1 */}
+            <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+              <div className="bg-[#f5f9ff] inline-flex items-center px-3 h-6 rounded-full w-fit">
+                <span className="text-[12px] font-medium text-[#193cb8] tracking-[0.12px]">
+                  1. Ask
+                </span>
+              </div>
+              <div className="flex flex-col gap-2">
+                <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
+                  Ask Your Question
+                </h4>
+                <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                  Enter your research question in natural language to start the
+                  exploration.
+                </p>
+              </div>
+            </div>
+
+            {/* Step 2 */}
+            <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+              <div className="bg-[#ecfdf5] inline-flex items-center px-3 h-6 rounded-full w-fit">
+                <span className="text-[12px] font-medium text-[#006045] tracking-[0.12px]">
+                  2. Select data
+                </span>
+              </div>
+              <div className="flex flex-col gap-2">
+                <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
+                  Select Data Sources
+                </h4>
+                <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                  Choose relevant datasets that help answer and support your
+                  question.
+                </p>
+              </div>
+            </div>
+
+            {/* Step 3 */}
+            <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+              <div className="bg-[#fff7ed] inline-flex items-center px-3 h-6 rounded-full w-fit">
+                <span className="text-[12px] font-medium text-[#f54900] tracking-[0.12px]">
+                  3. Explore results
+                </span>
+              </div>
+              <div className="flex flex-col gap-2">
+                <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
+                  Analyze &amp; Explore
+                </h4>
+                <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                  Review explanations and insights showing how findings were
+                  generated.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/use-case/weather/layout.tsx
+++ b/src/app/use-case/weather/layout.tsx
@@ -1,0 +1,17 @@
+import DashboardLayout from "@/components/DashboardLayout";
+import WeatherTabBar from "./WeatherTabBar";
+
+export default function WeatherWorkspaceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col min-h-[calc(100vh-56px)]">
+        <WeatherTabBar />
+        <div className="flex-1">{children}</div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/use-case/weather/page.tsx
+++ b/src/app/use-case/weather/page.tsx
@@ -1,13 +1,5 @@
-"use client";
-
-import UseCasePageClient from "../UseCasePageClient";
+import { redirect } from "next/navigation";
 
 export default function WeatherPage() {
-  return (
-    <UseCasePageClient
-      collectionName="Weather"
-      title="Weather Datasets"
-      subtitle="Weather dataset collection"
-    />
-  );
+  redirect("/use-case/weather/home");
 }


### PR DESCRIPTION
## Summary

- Add 3-tab Weather workspace layout (`/use-case/weather`) with Home, Chat, and Datasets tabs
- **Home** — hero section, Start Research card, and How it works steps (from Figma design)
- **Datasets** — reuses `UseCasePageClient` with `withLayout={false}` to show BE-filtered dataset list with search and smart search
- **Chat** — embeds full chat interface (without extra layout wrapper) with "meteo" custom collection pre-selected on load
- Add `withLayout` and `forcedCollectionId` props to `ChatPageContent` to support embedded use without `DashboardLayout`

## Test plan

- [ ] Navigate to `/use-case/weather` — should redirect to `/use-case/weather/home`
- [ ] Verify tab bar highlights active tab correctly for each sub-route
- [ ] Datasets tab: datasets filtered to Weather collection load correctly, search and smart search work
- [ ] Chat tab: chat interface appears, "meteo" collection is pre-selected in the collection picker
- [ ] `/chat` (standalone) still works correctly with layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)