### PR TITLE
DG-189 | Math pilot workspace

### DIFF
--- a/src/app/use-case/math/MathTabBar.tsx
+++ b/src/app/use-case/math/MathTabBar.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Database, House, MessageCircle } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const TABS = [
+  { label: "Home", href: "/use-case/math/home", Icon: House },
+  { label: "Chat", href: "/use-case/math/chat", Icon: MessageCircle },
+  { label: "Datasets", href: "/use-case/math/datasets", Icon: Database },
+] as const;
+
+export default function MathTabBar() {
+  const pathname = usePathname();
+  return (
+    <div className="bg-white border-b border-[#e2e8f0] flex h-14 items-start justify-center px-5 w-full shrink-0">
+      <div className="flex gap-4 items-center w-full max-w-[900px]">
+        {TABS.map(({ label, href, Icon }) => {
+          const isActive = pathname === href;
+          return (
+            <Link
+              key={href}
+              href={href}
+              className="relative flex h-[55px] items-end justify-center"
+            >
+              <div className="flex gap-1.5 items-center h-full justify-center px-2">
+                <Icon
+                  size={16}
+                  className={isActive ? "text-[#2b7fff]" : "text-[#5b708f]"}
+                />
+                <span
+                  className={`text-base font-medium leading-[1.5] whitespace-nowrap ${isActive ? "text-[#314158]" : "text-[#5b708f]"}`}
+                >
+                  {label}
+                </span>
+              </div>
+              {isActive && (
+                <div className="absolute bottom-0 left-0 right-0 h-[3px] bg-[#2b7fff] rounded-tl-sm rounded-tr-sm" />
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/use-case/math/chat/page.tsx
+++ b/src/app/use-case/math/chat/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Suspense } from "react";
+import { ChatPageContent } from "@/app/chat/page";
+import { useCollections } from "@/contexts/CollectionsContext";
+
+function MathChatInner() {
+  const { collections } = useCollections();
+  const mathCollection = collections.find(
+    (c) => c.name?.toLowerCase().trim() === "math",
+  );
+
+  return (
+    <ChatPageContent
+      withLayout={false}
+      forcedCollectionId={mathCollection?.id ?? null}
+      showConversationName={false}
+      hideCollectionActions={true}
+    />
+  );
+}
+
+export default function MathChatPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <MathChatInner />
+    </Suspense>
+  );
+}

--- a/src/app/use-case/math/datasets/page.tsx
+++ b/src/app/use-case/math/datasets/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import UseCasePageClient from "../../UseCasePageClient";
+
+export default function MathDatasetsPage() {
+  return (
+    <UseCasePageClient
+      collectionName="Math"
+      title="Math Datasets"
+      subtitle="Math dataset collection"
+      withLayout={false}
+    />
+  );
+}

--- a/src/app/use-case/math/home/page.tsx
+++ b/src/app/use-case/math/home/page.tsx
@@ -1,0 +1,108 @@
+import { ArrowRight, Search } from "lucide-react";
+import Link from "next/link";
+
+export default function MathHomePage() {
+  return (
+    <div className="flex justify-center px-5 py-10">
+      <div className="flex flex-col gap-6 w-full max-w-[900px]">
+        {/* Hero */}
+        <div className="flex flex-col gap-2">
+          <h1 className="text-[32px] font-semibold text-[#314158] leading-[1.4]">
+            Explore Math data with AI
+          </h1>
+          <p className="text-[20px] font-normal text-[#5b708f] leading-[1.4]">
+            Ask questions in natural language get answers from real data
+          </p>
+        </div>
+
+        {/* Start Research card */}
+        <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-6 justify-between">
+          <div className="flex flex-col gap-6">
+            <div className="bg-[#f5f9ff] rounded-lg p-2 w-10 h-10 flex items-center justify-center">
+              <Search size={20} className="text-[#2b7fff]" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <h2 className="text-[20px] font-semibold text-[#314158] leading-[1.4]">
+                Start Your Research
+              </h2>
+              <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                Get reliable answers grounded in real math data.
+                <br />
+                Explore patterns, trends, and evidence across trusted datasets.
+              </p>
+            </div>
+          </div>
+          <Link
+            href="/use-case/math/chat"
+            className="inline-flex items-center gap-2 bg-[#052f4a] text-white text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] w-fit shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)]"
+          >
+            Start Research
+            <ArrowRight size={16} />
+          </Link>
+        </div>
+
+        {/* How it works */}
+        <div className="flex flex-col gap-4">
+          <h3 className="text-[16px] font-semibold text-[#314158] leading-[1.5]">
+            How it works?
+          </h3>
+          <div className="grid grid-cols-3 gap-4">
+            {/* Step 1 */}
+            <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+              <div className="bg-[#f5f9ff] inline-flex items-center px-3 h-6 rounded-full w-fit">
+                <span className="text-[12px] font-medium text-[#193cb8] tracking-[0.12px]">
+                  1. Ask
+                </span>
+              </div>
+              <div className="flex flex-col gap-2">
+                <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
+                  Ask Your Question
+                </h4>
+                <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                  Enter your research question in natural language to start the
+                  exploration.
+                </p>
+              </div>
+            </div>
+
+            {/* Step 2 */}
+            <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+              <div className="bg-[#ecfdf5] inline-flex items-center px-3 h-6 rounded-full w-fit">
+                <span className="text-[12px] font-medium text-[#006045] tracking-[0.12px]">
+                  2. Select data
+                </span>
+              </div>
+              <div className="flex flex-col gap-2">
+                <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
+                  Select Data Sources
+                </h4>
+                <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                  Choose relevant datasets that help answer and support your
+                  question.
+                </p>
+              </div>
+            </div>
+
+            {/* Step 3 */}
+            <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+              <div className="bg-[#fff7ed] inline-flex items-center px-3 h-6 rounded-full w-fit">
+                <span className="text-[12px] font-medium text-[#f54900] tracking-[0.12px]">
+                  3. Explore results
+                </span>
+              </div>
+              <div className="flex flex-col gap-2">
+                <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
+                  Analyze &amp; Explore
+                </h4>
+                <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                  Review explanations and insights showing how findings were
+                  generated.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/use-case/math/layout.tsx
+++ b/src/app/use-case/math/layout.tsx
@@ -1,0 +1,17 @@
+import DashboardLayout from "@/components/DashboardLayout";
+import MathTabBar from "./MathTabBar";
+
+export default function MathWorkspaceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col min-h-[calc(100vh-56px)]">
+        <MathTabBar />
+        <div className="flex-1">{children}</div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/use-case/math/page.tsx
+++ b/src/app/use-case/math/page.tsx
@@ -1,13 +1,5 @@
-"use client";
-
-import UseCasePageClient from "../UseCasePageClient";
+import { redirect } from "next/navigation";
 
 export default function MathPage() {
-  return (
-    <UseCasePageClient
-      collectionName="Math"
-      title="Math Datasets"
-      subtitle="Math dataset collection"
-    />
-  );
+  redirect("/use-case/math/home");
 }


### PR DESCRIPTION
## Summary

- Add 3-tab Math workspace layout (`/use-case/math`) with Home, Chat, and Datasets tabs
- **Home** — hero section, Start Research card, and How it works steps (mirrors Weather pilot design)
- **Datasets** — reuses `UseCasePageClient` with `withLayout={false}` for BE-filtered Math dataset list with search and smart search
- **Chat** — embeds full chat interface without extra layout wrapper, pre-selects "math" collection on load
- Redirect `/use-case/math` to `/use-case/math/home`

## Test plan

- [ ] Navigate to `/use-case/math` — should redirect to `/use-case/math/home`
- [ ] Verify tab bar highlights active tab correctly for each sub-route
- [ ] Datasets tab: datasets filtered to Math collection load correctly, search and smart search work
- [ ] Chat tab: chat interface appears, "math" collection is pre-selected in the collection picker
- [ ] `/use-case/weather` still works correctly (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)