### PR TITLE
DG-190 | Language pilot workspace

### DIFF
--- a/src/app/use-case/language/LanguageTabBar.tsx
+++ b/src/app/use-case/language/LanguageTabBar.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ChartColumn, Database, House, MessageCircle } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const TABS = [
+  { label: "Home", href: "/use-case/language/home", Icon: House },
+  {
+    label: "Question",
+    href: "/use-case/language/question",
+    Icon: MessageCircle,
+  },
+  { label: "Analysis", href: "/use-case/language/analysis", Icon: ChartColumn },
+  { label: "Datasets", href: "/use-case/language/datasets", Icon: Database },
+] as const;
+
+export default function LanguageTabBar() {
+  const pathname = usePathname();
+  return (
+    <div className="bg-white border-b border-[#e2e8f0] flex h-14 items-start justify-center px-5 w-full shrink-0">
+      <div className="flex gap-4 items-center w-full max-w-[900px]">
+        {TABS.map(({ label, href, Icon }) => {
+          const isActive = pathname === href;
+          return (
+            <Link
+              key={href}
+              href={href}
+              className="relative flex h-[55px] items-end justify-center"
+            >
+              <div className="flex gap-1.5 items-center h-full justify-center px-2">
+                <Icon
+                  size={16}
+                  className={isActive ? "text-[#2b7fff]" : "text-[#5b708f]"}
+                />
+                <span
+                  className={`text-base font-medium leading-[1.5] whitespace-nowrap ${isActive ? "text-[#314158]" : "text-[#5b708f]"}`}
+                >
+                  {label}
+                </span>
+              </div>
+              {isActive && (
+                <div className="absolute bottom-0 left-0 right-0 h-[3px] bg-[#2b7fff] rounded-tl-sm rounded-tr-sm" />
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/use-case/language/analysis/page.tsx
+++ b/src/app/use-case/language/analysis/page.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+import { ArrowLeft, Download } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface TermFreqRow {
+  token: string;
+  frequency: number;
+}
+
+interface SentimentData {
+  positive: number;
+  neutral: number;
+  negative: number;
+  avgSentiment: number;
+  confidence: number;
+  totalDocs: number;
+}
+
+interface CollocationRow {
+  bigram: string;
+  frequency: number;
+  pmi: number;
+}
+
+interface AnalysisState {
+  query: string;
+  features: {
+    termFrequency: boolean;
+    sentimentProfile: boolean;
+    collocations: boolean;
+  };
+  termFreqData: TermFreqRow[];
+  sentimentData: SentimentData | null;
+  collocationData: CollocationRow[];
+}
+
+function mapResponse(
+  raw: any,
+): Pick<AnalysisState, "termFreqData" | "sentimentData" | "collocationData"> {
+  const features: any[] = Array.isArray(raw?.features) ? raw.features : [];
+  if (features.length === 0) {
+    return { termFreqData: [], sentimentData: null, collocationData: [] };
+  }
+
+  // Aggregate term frequency — sum counts across all feature chunks, sort by count desc
+  const termCounts = new Map<string, number>();
+  for (const feature of features) {
+    for (const item of Array.isArray(feature.term_frequency)
+      ? feature.term_frequency
+      : []) {
+      const term = String(item.term ?? "").trim();
+      if (!term) continue;
+      termCounts.set(
+        term,
+        (termCounts.get(term) ?? 0) + Number(item.count ?? 0),
+      );
+    }
+  }
+  const termFreqData: TermFreqRow[] = Array.from(termCounts.entries())
+    .map(([token, frequency]) => ({ token, frequency }))
+    .sort((a, b) => b.frequency - a.frequency)
+    .slice(0, 20);
+
+  // Aggregate sentiment — sum term counts, average polarity/subjectivity scores
+  let posTerms = 0;
+  let negTerms = 0;
+  let neutTerms = 0;
+  let totalTerms = 0;
+  let polaritySum = 0;
+  let subjectivitySum = 0;
+  for (const feature of features) {
+    const sp = feature.sentiment_profile ?? {};
+    posTerms += Number(sp.positive_terms ?? 0);
+    negTerms += Number(sp.negative_terms ?? 0);
+    neutTerms += Number(sp.neutral_terms ?? 0);
+    totalTerms += Number(sp.total_terms ?? 0);
+    polaritySum += Number(sp.polarity_score ?? 0);
+    subjectivitySum += Number(sp.subjectivity_score ?? 0);
+  }
+  const denom = totalTerms || 1;
+  const sentimentData: SentimentData = {
+    positive: (posTerms / denom) * 100,
+    neutral: (neutTerms / denom) * 100,
+    negative: (negTerms / denom) * 100,
+    avgSentiment: polaritySum / features.length,
+    confidence: subjectivitySum / features.length,
+    totalDocs: features.length,
+  };
+
+  // Aggregate collocations — join terms[] to bigram, sum counts, take max association_score
+  const colMap = new Map<string, { count: number; score: number }>();
+  for (const feature of features) {
+    for (const col of Array.isArray(feature.collocations)
+      ? feature.collocations
+      : []) {
+      const terms: string[] = Array.isArray(col.terms) ? col.terms : [];
+      const bigram = terms.join(" ");
+      if (!bigram) continue;
+      const existing = colMap.get(bigram);
+      if (existing) {
+        existing.count += Number(col.count ?? 0);
+        existing.score = Math.max(
+          existing.score,
+          Number(col.association_score ?? 0),
+        );
+      } else {
+        colMap.set(bigram, {
+          count: Number(col.count ?? 0),
+          score: Number(col.association_score ?? 0),
+        });
+      }
+    }
+  }
+  const collocationData: CollocationRow[] = Array.from(colMap.entries())
+    .map(([bigram, { count, score }]) => ({
+      bigram,
+      frequency: count,
+      pmi: score,
+    }))
+    .sort((a, b) => b.pmi - a.pmi)
+    .slice(0, 20);
+
+  return { termFreqData, sentimentData, collocationData };
+}
+
+function DonutChart({ data }: { data: SentimentData }) {
+  const total = data.positive + data.neutral + data.negative || 1;
+  const r = 60;
+  const cx = 80;
+  const cy = 80;
+  const circumference = 2 * Math.PI * r;
+
+  const segments = [
+    { value: data.positive, color: "#2b7fff" },
+    { value: data.neutral, color: "#94a3b8" },
+    { value: data.negative, color: "#f54900" },
+  ];
+
+  let cumulative = 0;
+  const arcs = segments.map((seg) => {
+    const offset = (1 - cumulative / total) * circumference;
+    const dasharray = (seg.value / total) * circumference;
+    cumulative += seg.value;
+    return { ...seg, offset, dasharray };
+  });
+
+  const dominantPct = Math.round((data.positive / total) * 100);
+
+  return (
+    <svg width="160" height="160" viewBox="0 0 160 160">
+      {arcs.map((arc, i) => (
+        <circle
+          key={i}
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill="none"
+          stroke={arc.color}
+          strokeWidth="24"
+          strokeDasharray={`${arc.dasharray} ${circumference - arc.dasharray}`}
+          strokeDashoffset={arc.offset}
+          transform={`rotate(-90 ${cx} ${cy})`}
+        />
+      ))}
+      <circle cx={cx} cy={cy} r={48} fill="white" />
+      <text
+        x={cx}
+        y={cy - 6}
+        textAnchor="middle"
+        fontSize="18"
+        fontWeight="600"
+        fill="#314158"
+      >
+        {dominantPct}%
+      </text>
+      <text x={cx} y={cy + 12} textAnchor="middle" fontSize="11" fill="#5b708f">
+        Positive
+      </text>
+    </svg>
+  );
+}
+
+export default function LanguageAnalysisPage() {
+  const router = useRouter();
+  const [state, setState] = useState<AnalysisState | null>(null);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem("language_analysis");
+    if (!stored) return;
+    try {
+      const parsed = JSON.parse(stored);
+      const mapped = mapResponse(parsed.result ?? {});
+      setState({
+        query: parsed.query ?? "",
+        features: parsed.features ?? {
+          termFrequency: true,
+          sentimentProfile: true,
+          collocations: true,
+        },
+        ...mapped,
+      });
+    } catch {
+      // ignore parse errors
+    }
+  }, []);
+
+  const showTermFreq = state?.features.termFrequency ?? true;
+  const showSentiment = state?.features.sentimentProfile ?? true;
+  const showCollocations = state?.features.collocations ?? true;
+
+  const termFreqData = state?.termFreqData ?? [];
+  const sentimentData = state?.sentimentData ?? null;
+  const collocationData = state?.collocationData ?? [];
+
+  return (
+    <div className="flex justify-center px-5 py-10">
+      <div className="flex flex-col gap-8 w-full max-w-[900px]">
+        {/* Top nav */}
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="inline-flex items-center gap-2 bg-white border border-[#cad5e2] text-[#314158] text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)]"
+          >
+            <ArrowLeft size={16} />
+            Back
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center bg-white border border-[#cad5e2] text-[#314158] w-10 h-10 rounded-[40px] shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)]"
+          >
+            <Download size={16} />
+          </button>
+        </div>
+
+        {/* Title */}
+        <div className="flex flex-col gap-2">
+          <h1 className="text-[32px] font-semibold text-[#314158] leading-[1.4]">
+            Analysis Workspace
+          </h1>
+          {state?.query && (
+            <p className="text-[20px] font-normal text-[#5b708f] leading-[1.4]">
+              {state.query}
+            </p>
+          )}
+          {!state?.query && (
+            <p className="text-[20px] font-normal text-[#5b708f] leading-[1.4]">
+              Feature extraction, concept tracking and document grouping
+            </p>
+          )}
+        </div>
+
+        {/* Term Frequency */}
+        {showTermFreq && termFreqData.length > 0 && (
+          <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4]">
+                Term Frequency
+              </h2>
+              <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                Most frequent tokens across selected documents
+              </p>
+            </div>
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[#e2e8f0]">
+                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
+                    #
+                  </th>
+                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
+                    Token
+                  </th>
+                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
+                    Frequency
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#e2e8f0]">
+                {termFreqData.map((row, i) => (
+                  <tr key={row.token}>
+                    <td className="py-3 text-[14px] text-[#8095ad]">{i + 1}</td>
+                    <td className="py-3 text-[14px] font-medium text-[#314158]">
+                      {row.token}
+                    </td>
+                    <td className="py-3 text-[14px] text-[#314158] text-right">
+                      {row.frequency.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Sentiment Profile */}
+        {showSentiment && sentimentData && (
+          <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+            <div className="flex items-center gap-3">
+              <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4] flex-1">
+                Sentiment Profile
+              </h2>
+              {sentimentData.totalDocs > 0 && (
+                <span className="inline-flex items-center px-3 h-6 rounded-full bg-[#f1f5f9] text-[12px] font-medium text-[#5b708f]">
+                  {sentimentData.totalDocs.toLocaleString()} docs
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-8">
+              <DonutChart data={sentimentData} />
+              <div className="flex flex-col gap-3 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="w-3 h-3 rounded-full bg-[#2b7fff] shrink-0" />
+                  <span className="flex-1 text-[14px] text-[#314158]">
+                    Positive
+                  </span>
+                  <span className="text-[14px] font-medium text-[#314158]">
+                    {Math.round(sentimentData.positive)}%
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="w-3 h-3 rounded-full bg-[#94a3b8] shrink-0" />
+                  <span className="flex-1 text-[14px] text-[#314158]">
+                    Neutral
+                  </span>
+                  <span className="text-[14px] font-medium text-[#314158]">
+                    {Math.round(sentimentData.neutral)}%
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="w-3 h-3 rounded-full bg-[#f54900] shrink-0" />
+                  <span className="flex-1 text-[14px] text-[#314158]">
+                    Negative
+                  </span>
+                  <span className="text-[14px] font-medium text-[#314158]">
+                    {Math.round(sentimentData.negative)}%
+                  </span>
+                </div>
+              </div>
+              <div className="flex flex-col gap-3">
+                <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
+                  <span className="text-[24px] font-semibold text-[#314158]">
+                    {sentimentData.avgSentiment >= 0 ? "+" : ""}
+                    {sentimentData.avgSentiment.toFixed(3)}
+                  </span>
+                  <span className="text-[12px] font-normal text-[#5b708f]">
+                    avg sentiment
+                  </span>
+                </div>
+                <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
+                  <span className="text-[24px] font-semibold text-[#314158]">
+                    {sentimentData.confidence.toFixed(3)}
+                  </span>
+                  <span className="text-[12px] font-normal text-[#5b708f]">
+                    confidence score
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Collocations */}
+        {showCollocations && collocationData.length > 0 && (
+          <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4]">
+                Collocations
+              </h2>
+              <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                Statistically significant word pairs by pointwise mutual
+                information
+              </p>
+            </div>
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[#e2e8f0]">
+                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
+                    #
+                  </th>
+                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
+                    Bigram
+                  </th>
+                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
+                    Frequency
+                  </th>
+                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
+                    PMI
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#e2e8f0]">
+                {collocationData.map((row, i) => (
+                  <tr key={row.bigram}>
+                    <td className="py-3 text-[14px] text-[#8095ad]">{i + 1}</td>
+                    <td className="py-3 text-[14px] font-medium text-[#314158]">
+                      {row.bigram}
+                    </td>
+                    <td className="py-3 text-[14px] text-[#314158] text-right">
+                      {row.frequency}
+                    </td>
+                    <td className="py-3 text-[14px] text-[#314158] text-right">
+                      {row.pmi.toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Empty state when no data and no features selected */}
+        {state &&
+          !termFreqData.length &&
+          !sentimentData &&
+          !collocationData.length && (
+            <div className="bg-white border border-[#e2e8f0] rounded-2xl p-10 flex flex-col items-center gap-2">
+              <p className="text-[16px] font-medium text-[#314158]">
+                No analysis data available
+              </p>
+              <p className="text-[14px] text-[#5b708f]">
+                Try enabling analysis components or selecting datasets with more
+                data.
+              </p>
+            </div>
+          )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/use-case/language/datasets/page.tsx
+++ b/src/app/use-case/language/datasets/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import UseCasePageClient from "../../UseCasePageClient";
+
+export default function LanguageDatasetsPage() {
+  return (
+    <UseCasePageClient
+      collectionName="Language"
+      title="Language Datasets"
+      subtitle="Language dataset collection"
+      withLayout={false}
+    />
+  );
+}

--- a/src/app/use-case/language/home/page.tsx
+++ b/src/app/use-case/language/home/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { ArrowRight, Search } from "lucide-react";
+import Link from "next/link";
+import { Tooltip } from "@/components/ui/Tooltip";
+
+export default function LanguageHomePage() {
+  return (
+    <div className="flex justify-center px-5 py-10">
+      <div className="flex flex-col gap-6 w-full max-w-[900px]">
+        {/* Hero */}
+        <div className="flex flex-col gap-2">
+          <h1 className="text-[32px] font-semibold text-[#314158] leading-[1.4]">
+            Explore language data with AI
+          </h1>
+          <p className="text-[20px] font-normal text-[#5b708f] leading-[1.4]">
+            Ask questions in natural language get answers from real data
+          </p>
+        </div>
+
+        {/* Start Research card — horizontal layout */}
+        <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex items-center gap-6">
+          <div className="bg-[#f5f9ff] rounded-lg p-2 w-10 h-10 flex items-center justify-center shrink-0">
+            <Search size={20} className="text-[#2b7fff]" />
+          </div>
+          <div className="flex flex-col gap-1 flex-1">
+            <h2 className="text-[18px] font-semibold text-[#1d293d] leading-[1.4]">
+              Start Your Research
+            </h2>
+            <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+              Get reliable answers grounded in real language data.
+            </p>
+          </div>
+          <Link
+            href="/use-case/language/question"
+            className="inline-flex items-center gap-2 bg-[#052f4a] text-white text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] shrink-0 shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)]"
+          >
+            Start Research
+            <ArrowRight size={16} />
+          </Link>
+        </div>
+
+        {/* How it works */}
+        <div className="grid grid-cols-3 gap-4">
+          <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+            <div className="bg-[#f5f9ff] inline-flex items-center px-3 h-6 rounded-full w-fit">
+              <span className="text-[12px] font-medium text-[#193cb8] tracking-[0.12px]">
+                01
+              </span>
+            </div>
+            <div className="flex flex-col gap-2">
+              <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
+                Ask Your Question
+              </h4>
+              <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                Write your research question in natural language.
+              </p>
+            </div>
+          </div>
+          <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+            <div className="bg-[#ecfdf5] inline-flex items-center px-3 h-6 rounded-full w-fit">
+              <span className="text-[12px] font-medium text-[#006045] tracking-[0.12px]">
+                02
+              </span>
+            </div>
+            <div className="flex flex-col gap-2">
+              <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
+                Select Data Sources
+              </h4>
+              <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                Browse available datasets and select those relevant to your
+                question.
+              </p>
+            </div>
+          </div>
+          <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
+            <div className="bg-[#fff7ed] inline-flex items-center px-3 h-6 rounded-full w-fit">
+              <span className="text-[12px] font-medium text-[#f54900] tracking-[0.12px]">
+                03
+              </span>
+            </div>
+            <div className="flex flex-col gap-2">
+              <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
+                Analyze &amp; Explore
+              </h4>
+              <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                Explore explanations showing how concepts influenced findings.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Example Research Questions */}
+        <div className="flex flex-col gap-4">
+          <h3 className="text-[16px] font-semibold text-[#314158] leading-[1.5]">
+            Example Research Questions
+          </h3>
+          <div className="grid grid-cols-2 gap-4">
+            <Tooltip
+              content="Coming soon"
+              position="top"
+              delay={200}
+              className="flex"
+            >
+              <div
+                className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-6 w-full opacity-80 cursor-default"
+                style={{ pointerEvents: "none" }}
+              >
+                <div className="flex flex-col gap-4">
+                  <div className="bg-[#f5f9ff] rounded-lg p-2 w-10 h-10 flex items-center justify-center">
+                    <Search size={20} className="text-[#2b7fff]" />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <h4 className="text-[18px] font-semibold text-[#1d293d] leading-[1.4]">
+                      Track concept evolution
+                    </h4>
+                    <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                      How did &lsquo;democracy&rsquo; change in news 2000-2020?
+                    </p>
+                  </div>
+                </div>
+                <button className="inline-flex items-center justify-center bg-white border border-[#cad5e2] text-[#314158] text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] w-fit shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)]">
+                  Check Example
+                </button>
+              </div>
+            </Tooltip>
+            <Tooltip
+              content="Coming soon"
+              position="top"
+              delay={200}
+              className="flex"
+            >
+              <div
+                className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-6 w-full opacity-80 cursor-default"
+                style={{ pointerEvents: "none" }}
+              >
+                <div className="flex flex-col gap-4">
+                  <div className="bg-[#f5f9ff] rounded-lg p-2 w-10 h-10 flex items-center justify-center">
+                    <Search size={20} className="text-[#2b7fff]" />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <h4 className="text-[18px] font-semibold text-[#1d293d] leading-[1.4]">
+                      Compare linguistic features
+                    </h4>
+                    <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
+                      Sentiment patterns across political speeches
+                    </p>
+                  </div>
+                </div>
+                <button className="inline-flex items-center justify-center bg-white border border-[#cad5e2] text-[#314158] text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] w-fit shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)]">
+                  Check Example
+                </button>
+              </div>
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/use-case/language/layout.tsx
+++ b/src/app/use-case/language/layout.tsx
@@ -1,0 +1,17 @@
+import DashboardLayout from "@/components/DashboardLayout";
+import LanguageTabBar from "./LanguageTabBar";
+
+export default function LanguageWorkspaceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col min-h-[calc(100vh-56px)]">
+        <LanguageTabBar />
+        <div className="flex-1">{children}</div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/use-case/language/page.tsx
+++ b/src/app/use-case/language/page.tsx
@@ -1,13 +1,5 @@
-"use client";
-
-import UseCasePageClient from "../UseCasePageClient";
+import { redirect } from "next/navigation";
 
 export default function LanguagePage() {
-  return (
-    <UseCasePageClient
-      collectionName="Language"
-      title="Language Datasets"
-      subtitle="Language dataset collection"
-    />
-  );
+  redirect("/use-case/language/home");
 }

--- a/src/app/use-case/language/question/page.tsx
+++ b/src/app/use-case/language/question/page.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { ArrowLeft, ArrowRight, ArrowUpRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import DGIcon from "@/components/ui/chat/DGIcon";
+import { useApi } from "@/hooks/useApi";
+
+function Toggle({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onChange}
+      className={`flex items-center p-[2px] w-[28px] h-[16px] rounded-full transition-colors shrink-0 ${
+        checked ? "bg-[#052f4a] justify-end" : "bg-[#e2e8f0] justify-start"
+      }`}
+    >
+      <span className="w-[12px] h-[12px] bg-white rounded-full shadow-[0px_0.6px_0.6px_0px_rgba(213,218,227,0.3)]" />
+    </button>
+  );
+}
+
+export default function LanguageQuestionPage() {
+  const router = useRouter();
+  const api = useApi();
+  const [question, setQuestion] = useState("");
+  const [submittedQuestion, setSubmittedQuestion] = useState("");
+  const [phase, setPhase] = useState<"input" | "analysis">("input");
+  const [termFrequency, setTermFrequency] = useState(true);
+  const [sentimentProfile, setSentimentProfile] = useState(true);
+  const [collocations, setCollocations] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const handleSubmit = () => {
+    if (!question.trim()) return;
+    setSubmittedQuestion(question.trim());
+    setPhase("analysis");
+  };
+
+  const fetchLanguageDatasetIds = async (): Promise<string[]> => {
+    const data = await api.queryDatasets({
+      project: { fields: ["id", "collections.id", "collections.name"] },
+      page: { Offset: 0, Size: 100 },
+      Order: { Items: ["+code"] },
+      Metadata: { CountAll: true },
+    });
+    const items: unknown[] = Array.isArray(data.items) ? data.items : [];
+    return items
+      .filter(
+        (d): d is Record<string, unknown> =>
+          typeof d === "object" && d !== null,
+      )
+      .filter((d) =>
+        (Array.isArray(d.collections) ? d.collections : []).some(
+          (c: any) =>
+            String(c?.name ?? "")
+              .toLowerCase()
+              .trim() === "language",
+        ),
+      )
+      .map((d) => String(d.id))
+      .filter(Boolean);
+  };
+
+  const handleStartAnalysis = async () => {
+    setIsSubmitting(true);
+    setSubmitError(null);
+    try {
+      const datasetIds = await fetchLanguageDatasetIds();
+      const result = await api.getLinguisticFeatures({
+        DatasetIds: datasetIds,
+        Query: submittedQuestion,
+      });
+      sessionStorage.setItem(
+        "language_analysis",
+        JSON.stringify({
+          query: submittedQuestion,
+          features: { termFrequency, sentimentProfile, collocations },
+          result,
+        }),
+      );
+      router.push("/use-case/language/analysis");
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error
+          ? err.message
+          : "Analysis failed. Please try again.",
+      );
+      setIsSubmitting(false);
+    }
+  };
+
+  if (phase === "analysis") {
+    return (
+      <div className="flex items-center justify-center flex-1 px-5 py-10 min-h-[calc(100vh-56px-56px)]">
+        <div className="flex flex-col gap-8 items-center w-full max-w-[900px]">
+          {/* Header */}
+          <div className="flex flex-col gap-2 items-center w-full">
+            <DGIcon />
+            <h1 className="text-[24px] font-semibold text-[#314158] leading-[1.4] text-center">
+              {submittedQuestion}
+            </h1>
+          </div>
+
+          {/* Analysis components card */}
+          <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4 w-full">
+            <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4]">
+              Select analysis components
+            </h2>
+            <div className="flex flex-col divide-y divide-[#e2e8f0]">
+              <div className="flex items-center gap-4 h-10">
+                <span className="flex-1 text-[16px] font-normal text-[#314158] leading-[1.5]">
+                  Term frequency
+                </span>
+                <Toggle
+                  checked={termFrequency}
+                  onChange={() => setTermFrequency((v) => !v)}
+                />
+              </div>
+              <div className="flex items-center gap-4 h-10">
+                <span className="flex-1 text-[16px] font-normal text-[#314158] leading-[1.5]">
+                  Sentiment profile
+                </span>
+                <Toggle
+                  checked={sentimentProfile}
+                  onChange={() => setSentimentProfile((v) => !v)}
+                />
+              </div>
+              <div className="flex items-center gap-4 h-10">
+                <span className="flex-1 text-[16px] font-normal text-[#314158] leading-[1.5]">
+                  Collocations
+                </span>
+                <Toggle
+                  checked={collocations}
+                  onChange={() => setCollocations((v) => !v)}
+                />
+              </div>
+            </div>
+          </div>
+
+          {submitError && (
+            <p className="text-[14px] text-red-600 text-center">
+              {submitError}
+            </p>
+          )}
+
+          {/* Navigation */}
+          <div className="flex items-center justify-between w-full">
+            <button
+              type="button"
+              onClick={() => setPhase("input")}
+              disabled={isSubmitting}
+              className="inline-flex items-center gap-2 bg-white border border-[#cad5e2] text-[#314158] text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)] disabled:opacity-50"
+            >
+              <ArrowLeft size={16} />
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={handleStartAnalysis}
+              disabled={isSubmitting}
+              className="inline-flex items-center gap-2 bg-[#052f4a] text-white text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)] disabled:opacity-70"
+            >
+              {isSubmitting ? "Analyzing..." : "Start Analysis"}
+              {!isSubmitting && <ArrowRight size={16} />}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center flex-1 px-5 min-h-[calc(100vh-56px-56px)]">
+      <div className="flex flex-col gap-8 items-center w-full max-w-[900px]">
+        {/* Header */}
+        <div className="flex flex-col gap-2 items-center text-center">
+          <DGIcon />
+          <h1 className="text-[32px] font-semibold text-[#314158] leading-[1.4]">
+            Start your research
+          </h1>
+          <p className="text-[20px] font-normal text-[#566b88] leading-[1.4] max-w-[592px]">
+            Ask a natural language question to explore linguistic trends and
+            concepts across datasets.
+          </p>
+        </div>
+
+        {/* Input box */}
+        <div className="relative bg-white border border-[#e2e8f0] rounded-2xl w-full h-[155px] shadow-[0px_0px_0px_4px_rgba(202,213,226,0.25),0px_5px_8px_0px_rgba(144,156,178,0.1)] overflow-hidden">
+          <textarea
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            placeholder="Ask a question..."
+            className="w-full h-full resize-none p-[18px] pr-[60px] text-[16px] font-normal text-[#314158] leading-[1.5] placeholder:text-[#8095ad] outline-none bg-transparent"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                handleSubmit();
+              }
+            }}
+          />
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="absolute right-[10px] bottom-[10px] bg-[#052f4a] text-white p-2 rounded-[40px] flex items-center justify-center"
+          >
+            <ArrowUpRight size={24} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1354,6 +1354,35 @@ export function useApi() {
     [makeRequest],
   );
 
+  const getLinguisticFeatures = useCallback(
+    async (payload: { DatasetIds: string[]; Query: string }): Promise<any> => {
+      logApiRequest("getLinguisticFeatures", {
+        endpoint: "/pilot/language/linguistic-features",
+        payload,
+      });
+      const response = await makeRequest(
+        "/pilot/language/linguistic-features",
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+        },
+      );
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        logApiError("getLinguisticFeatures", errorData);
+        throw new Error(
+          errorData.error ||
+            errorData.message ||
+            "Failed to get linguistic features",
+        );
+      }
+      const result = await response.json();
+      logApiResponse("getLinguisticFeatures", result);
+      return result;
+    },
+    [makeRequest],
+  );
+
   const profileDataset = useCallback(
     async (datasetId: string, dataStoreKind: number): Promise<string> => {
       logApiRequest("profileDataset", {
@@ -1429,5 +1458,6 @@ export function useApi() {
     uploadDatasetFiles,
     onboardDataset,
     profileDataset,
+    getLinguisticFeatures,
   };
 }


### PR DESCRIPTION
## Summary
- 4-tab workspace layout: Home, Question, Analysis, Datasets
- Home page with "Start Research" CTA, How it works steps, and Coming Soon example panels
- Question page: natural language input → analysis component selection (Term Frequency / Sentiment Profile / Collocations toggles, all enabled by default) → calls `POST /pilot/language/linguistic-features` with query + language collection dataset IDs
- Analysis page: aggregates per-chunk API response across all features — sums term counts, aggregates sentiment term distribution, deduplicates collocations by association score; shows only sections toggled on
- Datasets tab: language collection filtered dataset list (reuses `UseCasePageClient`)
- `getLinguisticFeatures` added to `useApi`

## Test plan
- [ ] Navigate to `/use-case/language`
- [ ] Click "Start Research" → lands on Question page
- [ ] Type a question and submit → shows analysis component toggles
- [ ] Click "Start Analysis" → loading state shown, API called, navigates to Analysis page
- [ ] Verify Term Frequency, Sentiment Profile (donut chart + stat boxes), Collocations tables render with real data
- [ ] Toggle off a component on question page → corresponding section hidden on analysis page
- [ ] Datasets tab shows datasets filtered by language collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)