### PR TITLE
DG-162 | Connect dataset details preview to profileRaw

### DIFF
--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -82,6 +82,7 @@ export default function DatasetDetailsPage() {
               "language",
               "country",
               "citation",
+              "profileRaw",
             ],
           },
           ids: [datasetId],
@@ -334,5 +335,6 @@ function mapApiDatasetToDatasetPlus(api: unknown): DatasetPlus {
     language: obj.language ? String(obj.language) : undefined,
     country: obj.country ? String(obj.country) : undefined,
     citation: obj.citation ? String(obj.citation) : undefined,
+    profileRaw: obj.profileRaw ?? null,
   };
 }

--- a/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
+++ b/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
@@ -3,14 +3,18 @@
 import { Button } from "@ui/Button";
 import { ArrowLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { APP_ROUTES } from "@/config/appUrls";
 import { getDisplayCategory } from "@/config/collectionConstants";
 import type { DatasetPlus } from "@/data/dataset";
-import { getFilePreviewData } from "@/data/mockFilePreview";
+import { useApi } from "@/hooks/useApi";
+import { buildFilePreviews } from "@/lib/datasetProfile";
+import { logError } from "@/lib/logger";
 import { getNavigationUrl } from "@/lib/utils";
+import type { FilePreviewDataUnion } from "@/types/filePreview";
 import DatasetDescriptionSection from "./DatasetDescriptionSection/DatasetDescriptionSection";
 import styles from "./DatasetDetailsPageContent.module.scss";
+import type { FileNode } from "./DatasetFilesTree/DatasetFilesTree";
 import DatasetFilesTree from "./DatasetFilesTree/DatasetFilesTree";
 import DatasetHeader from "./DatasetHeader/DatasetHeader";
 import DatasetMetadataBar from "./DatasetMetadataBar/DatasetMetadataBar";
@@ -20,6 +24,17 @@ import DatasetSpecificationSection from "./DatasetSpecificationSection/DatasetSp
 import DatasetTagsSection from "./DatasetTagsSection/DatasetTagsSection";
 import DatasetUseCasesSection from "./DatasetUseCasesSection/DatasetUseCasesSection";
 import FilePreview from "./FilePreview/FilePreview";
+
+const JSON_PREVIEW_MAX_LINES = 150;
+
+function extensionFromMime(mime?: string): string | undefined {
+  if (!mime) return undefined;
+  if (mime.includes("csv")) return "csv";
+  if (mime.includes("spreadsheet") || mime.includes("excel")) return "xlsx";
+  if (mime.includes("pdf")) return "pdf";
+  if (mime.includes("json")) return "json";
+  return undefined;
+}
 
 interface DatasetDetailsPageContentProps {
   dataset: DatasetPlus;
@@ -31,28 +46,102 @@ export default function DatasetDetailsPageContent({
   returnToRoles = false,
 }: DatasetDetailsPageContentProps) {
   const router = useRouter();
-  const [selectedFileId, setSelectedFileId] = useState<string>("file1-csv");
+  const { downloadDatasetFile } = useApi();
 
-  const handleFileSelect = (
-    fileId: string,
-    _fileName: string,
-    extension?: string,
-  ) => {
-    const mockFileMap: Record<string, string> = {
-      file1: "file1-csv",
-      "csv-file1": "file1-csv",
-      "csv-file2": "file1-csv",
-      file2: "file2-xlsx",
-      "excel-file1": "file2-xlsx",
-      "pdf-file1": "file-pdf",
-      "json-file1": "file-json",
+  const previewEntries = useMemo(
+    () => buildFilePreviews(dataset.profileRaw),
+    [dataset.profileRaw],
+  );
+
+  const fileNodes: FileNode[] = useMemo(
+    () =>
+      previewEntries.map((entry) => ({
+        id: entry.id,
+        name: entry.name,
+        type: "file",
+        extension: extensionFromMime(entry.mimeType),
+      })),
+    [previewEntries],
+  );
+
+  const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
+  const [loadedContent, setLoadedContent] = useState<
+    Record<string, FilePreviewDataUnion>
+  >({});
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+
+  useEffect(() => {
+    if (!selectedFileId && previewEntries.length > 0) {
+      setSelectedFileId(previewEntries[0].id);
+    }
+  }, [previewEntries, selectedFileId]);
+
+  const selectedEntry = previewEntries.find(
+    (entry) => entry.id === selectedFileId,
+  );
+
+  // Tabular previews are fully described by the profile; JSON/PDF need the
+  // file bytes, fetched lazily on selection to save bandwidth.
+  useEffect(() => {
+    if (!selectedEntry) return;
+    const { id, data } = selectedEntry;
+    if (data.type === "tabular" || loadedContent[id]) return;
+
+    let cancelled = false;
+    setIsPreviewLoading(true);
+    (async () => {
+      try {
+        const response = await downloadDatasetFile(dataset.id, id);
+        if (data.type === "json") {
+          const text = await response.text();
+          const content = text
+            .split("\n")
+            .slice(0, JSON_PREVIEW_MAX_LINES)
+            .join("\n");
+          if (!cancelled) {
+            setLoadedContent((prev) => ({
+              ...prev,
+              [id]: { ...data, content },
+            }));
+          }
+        } else if (data.type === "pdf") {
+          const blob = await response.blob();
+          const fileUrl = URL.createObjectURL(blob);
+          if (!cancelled) {
+            setLoadedContent((prev) => ({
+              ...prev,
+              [id]: { ...data, fileUrl },
+            }));
+          }
+        }
+      } catch (error) {
+        logError("Failed to load file preview content", error, {
+          datasetId: dataset.id,
+          fileId: id,
+        });
+      } finally {
+        if (!cancelled) setIsPreviewLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
     };
+  }, [selectedEntry, dataset.id, downloadDatasetFile, loadedContent]);
 
-    const mappedFileId = mockFileMap[fileId] ?? "file1-csv";
-    setSelectedFileId(mappedFileId);
+  const filePreviewData: FilePreviewDataUnion | null = selectedEntry
+    ? (loadedContent[selectedEntry.id] ?? selectedEntry.data)
+    : null;
+
+  const isAwaitingContent =
+    selectedEntry != null &&
+    selectedEntry.data.type !== "tabular" &&
+    !loadedContent[selectedEntry.id] &&
+    isPreviewLoading;
+
+  const handleFileSelect = (fileId: string) => {
+    setSelectedFileId(fileId);
   };
-
-  const filePreviewData = getFilePreviewData(selectedFileId);
 
   const displayCategory = getDisplayCategory(
     dataset.collections,
@@ -154,11 +243,21 @@ export default function DatasetDetailsPageContent({
               <h2 className={styles.datasetDetailsPageContent__sectionTitle}>
                 File Preview
               </h2>
-              <FilePreview fileData={filePreviewData} />
+              {isAwaitingContent ? (
+                <div
+                  aria-busy="true"
+                  className="h-96 w-full animate-pulse rounded-lg bg-slate-100"
+                />
+              ) : (
+                <FilePreview fileData={filePreviewData} />
+              )}
             </div>
 
             <div className={styles.datasetDetailsPageContent__rowRight}>
-              <DatasetFilesTree onFileSelect={handleFileSelect} />
+              <DatasetFilesTree
+                files={fileNodes}
+                onFileSelect={handleFileSelect}
+              />
             </div>
           </div>
 

--- a/src/components/DatasetDetailsPage/FilePreview/PdfFilePreview.tsx
+++ b/src/components/DatasetDetailsPage/FilePreview/PdfFilePreview.tsx
@@ -27,8 +27,11 @@ export default function PdfFilePreview({
 
   const { filename, fileSize, description, keywords, fileUrl, totalPages } =
     data;
+  // profileRaw has no page count, so prefer the count from the loaded document.
+  const [numPages, setNumPages] = useState<number>(totalPages);
 
-  const remainingPages = Math.max(0, totalPages - PREVIEW_PAGE_LIMIT);
+  const effectivePages = numPages || totalPages;
+  const remainingPages = Math.max(0, effectivePages - PREVIEW_PAGE_LIMIT);
 
   const containerRef = useCallback((node: HTMLDivElement | null) => {
     if (node) {
@@ -53,6 +56,9 @@ export default function PdfFilePreview({
       >
         <Document
           file={fileUrl}
+          onLoadSuccess={({ numPages: loadedPages }) =>
+            setNumPages(loadedPages)
+          }
           loading={
             <div className={styles.pdfFilePreview__loading}>Loading PDF…</div>
           }
@@ -63,7 +69,7 @@ export default function PdfFilePreview({
           }
         >
           {Array.from(
-            { length: Math.min(PREVIEW_PAGE_LIMIT, totalPages) },
+            { length: Math.min(PREVIEW_PAGE_LIMIT, effectivePages) },
             (_, i) => (
               <Page
                 key={i}

--- a/src/data/dataset.ts
+++ b/src/data/dataset.ts
@@ -39,6 +39,7 @@ export type DatasetPlus = Dataset & {
   language?: string;
   country?: string;
   citation?: string;
+  profileRaw?: unknown;
 };
 
 export type DatasetWithCollections = Dataset & { collections?: Collection[] };

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -953,6 +953,67 @@ export function useApi() {
     [makeRequest],
   );
 
+  const getDatasetById = useCallback(
+    async (id: string, fields?: string[]): Promise<any> => {
+      const qs = buildFieldsQuery(fields);
+      logApiRequest("getDatasetById", { endpoint: `/dataset/${id}` });
+
+      const response = await makeRequest(
+        `/dataset/${encodeURIComponent(id)}${qs}`,
+        {
+          method: "GET",
+          headers: { "X-Request-Type": "getDatasetById" },
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        if (errorData && Object.keys(errorData).length > 0) {
+          logApiError("getDatasetById", errorData, { id });
+        }
+        throw new Error(
+          errorData.error || ApiErrorMessage.FETCH_DATASET_DETAILS_FAILED,
+        );
+      }
+
+      const result = await response.json();
+      logApiResponse("getDatasetById", { id });
+      return result;
+    },
+    [makeRequest],
+  );
+
+  const downloadDatasetFile = useCallback(
+    async (datasetId: string, fileObjectNodeId: string): Promise<Response> => {
+      logApiRequest("downloadDatasetFile", { datasetId, fileObjectNodeId });
+
+      const response = await makeRequest(
+        `/storage/download/dataset/${encodeURIComponent(datasetId)}/file-object/${encodeURIComponent(fileObjectNodeId)}`,
+        {
+          method: "GET",
+          headers: { "X-Request-Type": "downloadDatasetFile" },
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        if (errorData && Object.keys(errorData).length > 0) {
+          logApiError("downloadDatasetFile", errorData, {
+            datasetId,
+            fileObjectNodeId,
+          });
+        }
+        throw new Error(
+          errorData.error || ApiErrorMessage.DOWNLOAD_FILE_FAILED,
+        );
+      }
+
+      logApiResponse("downloadDatasetFile", { datasetId, fileObjectNodeId });
+      return response;
+    },
+    [makeRequest],
+  );
+
   const getUserFavorites = useCallback(
     async (
       fields: string[] = [
@@ -1530,6 +1591,8 @@ export function useApi() {
     createUserCollection,
     addDatasetToUserCollection,
     removeDatasetFromUserCollection,
+    getDatasetById,
+    downloadDatasetFile,
     getUserFavorites,
     addFavoriteDataset,
     removeFavoriteDataset,

--- a/src/lib/apiErrors.ts
+++ b/src/lib/apiErrors.ts
@@ -40,4 +40,5 @@ export enum ApiErrorMessage {
   FETCH_ALLOWED_EXTENSIONS_FAILED = "Failed to fetch allowed file extensions",
   ONBOARD_DATASET_FAILED = "Failed to onboard dataset",
   PROFILE_DATASET_FAILED = "Failed to profile dataset",
+  DOWNLOAD_FILE_FAILED = "Failed to download file",
 }

--- a/src/lib/datasetProfile.ts
+++ b/src/lib/datasetProfile.ts
@@ -1,0 +1,291 @@
+import type {
+  ColumnStatistics,
+  FileColumn,
+  FilePreviewDataUnion,
+  FileRow,
+} from "@/types/filePreview";
+
+/**
+ * Minimal shapes for the MOMA dataset profile (`profileRaw`), which is
+ * Croissant JSON-LD with a DataGEMS `dg:` extension. See
+ * datagems-eosc/dg-dataset-profiler docs/profile-examples-moma.md.
+ */
+interface CroissantStatistics {
+  rowCount?: number | null;
+  mean?: number | null;
+  median?: number | null;
+  standardDeviation?: number | null;
+  min?: number | string | null;
+  max?: number | string | null;
+  missingCount?: number | null;
+  missingPercentage?: number | null;
+  uniqueCount?: number | null;
+  histogram?: string | null;
+}
+
+interface CroissantField {
+  "@id"?: string;
+  name?: string;
+  description?: string;
+  dataType?: string;
+  source?: { fileObject?: { "@id"?: string } };
+  sample?: unknown[];
+  statistics?: CroissantStatistics;
+}
+
+interface CroissantRecordSet {
+  "@id"?: string;
+  name?: string;
+  field?: CroissantField[];
+}
+
+interface CroissantDistribution {
+  "@id"?: string;
+  name?: string;
+  contentSize?: string;
+  encodingFormat?: string;
+}
+
+export interface CroissantProfile {
+  distribution?: CroissantDistribution[];
+  recordSet?: CroissantRecordSet[];
+}
+
+export interface FilePreviewEntry {
+  id: string; // distribution @id — the fileObjectNodeId used for download
+  name: string;
+  mimeType?: string;
+  data: FilePreviewDataUnion;
+}
+
+const NUMERIC_TYPES = new Set([
+  "sc:Integer",
+  "sc:Float",
+  "sc:Number",
+  "sc:Decimal",
+  "sc:Long",
+]);
+
+const TABULAR_MIMES = new Set([
+  "text/csv",
+  "text/tab-separated-values",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]);
+
+const JSON_MIMES = new Set(["application/json", "application/x-ipynb+json"]);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseProfileRaw(raw: unknown): CroissantProfile | null {
+  if (raw == null) return null;
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return isObject(parsed) ? (parsed as CroissantProfile) : null;
+    } catch {
+      return null;
+    }
+  }
+  return isObject(raw) ? (raw as CroissantProfile) : null;
+}
+
+function mapColumnType(dataType?: string): FileColumn["type"] {
+  if (!dataType) return "categorical";
+  if (NUMERIC_TYPES.has(dataType)) return "numeric";
+  if (dataType === "sc:Boolean") return "boolean";
+  if (dataType === "sc:Date" || dataType === "sc:DateTime") return "date";
+  return "categorical";
+}
+
+function parseHistogram(histogram?: string | null): number[] | undefined {
+  if (!histogram) return undefined;
+  try {
+    const bins = JSON.parse(histogram);
+    if (!Array.isArray(bins)) return undefined;
+    return bins.map((bin) => {
+      const count = (bin as { count?: unknown })?.count;
+      return typeof count === "number" ? count : 0;
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+export function mapFieldStatistics(field: CroissantField): ColumnStatistics {
+  const source = field.statistics ?? {};
+  const stat: ColumnStatistics = {
+    columnId: field["@id"] ?? field.name ?? "",
+  };
+  if (typeof source.uniqueCount === "number")
+    stat.uniqueValues = source.uniqueCount;
+  if (typeof source.missingCount === "number")
+    stat.nullCount = source.missingCount;
+  if (source.min != null) stat.min = source.min;
+  if (source.max != null) stat.max = source.max;
+  if (typeof source.mean === "number") stat.mean = source.mean;
+  if (typeof source.median === "number") stat.median = source.median;
+  if (typeof source.standardDeviation === "number") {
+    stat.stdDev = source.standardDeviation;
+  }
+  if (typeof source.missingPercentage === "number") {
+    stat.missingPercentage = source.missingPercentage;
+  }
+  const distribution = parseHistogram(source.histogram);
+  if (distribution) stat.distribution = distribution;
+  return stat;
+}
+
+function normalizeCell(value: unknown): string | number | boolean | null {
+  if (value == null) return null;
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  return String(value);
+}
+
+export function transposeSamplesToRows(
+  fields: { "@id"?: string; sample?: unknown[] }[],
+  limit = 100,
+): FileRow[] {
+  const rowCount = Math.min(
+    limit,
+    fields.reduce((max, field) => Math.max(max, field.sample?.length ?? 0), 0),
+  );
+  const rows: FileRow[] = [];
+  for (let index = 0; index < rowCount; index++) {
+    rows.push({
+      id: String(index),
+      cells: fields.map((field) => ({
+        columnId: field["@id"] ?? "",
+        value: normalizeCell(field.sample?.[index]),
+      })),
+    });
+  }
+  return rows;
+}
+
+function recordSetForFile(
+  profile: CroissantProfile,
+  fileId: string,
+): CroissantRecordSet | undefined {
+  return profile.recordSet?.find((recordSet) =>
+    recordSet.field?.some(
+      (field) => field.source?.fileObject?.["@id"] === fileId,
+    ),
+  );
+}
+
+function buildTabular(
+  recordSet: CroissantRecordSet,
+  distribution: CroissantDistribution,
+): FilePreviewDataUnion {
+  const fields = recordSet.field ?? [];
+  const columns: FileColumn[] = fields.map((field) => ({
+    id: field["@id"] ?? field.name ?? "",
+    name: field.name ?? "",
+    type: mapColumnType(field.dataType),
+    visible: true,
+    description: field.description || undefined,
+  }));
+  const rows = transposeSamplesToRows(fields);
+  const statistics = fields.map(mapFieldStatistics);
+
+  const rowCounts = fields
+    .map((field) => field.statistics?.rowCount)
+    .filter((count): count is number => typeof count === "number");
+  const totalRows = rowCounts.length > 0 ? rowCounts[0] : rows.length;
+
+  const missingPercentages = fields
+    .map((field) => field.statistics?.missingPercentage)
+    .filter((value): value is number => typeof value === "number");
+  const totalMissingPercentage =
+    missingPercentages.length > 0
+      ? missingPercentages.reduce((sum, value) => sum + value, 0) /
+        missingPercentages.length
+      : undefined;
+
+  return {
+    type: "tabular",
+    filename: distribution.name ?? recordSet.name ?? "",
+    fileSize: distribution.contentSize ?? "",
+    description: "",
+    columns,
+    rows,
+    totalRows,
+    totalMissingPercentage,
+    statistics,
+    dataQuality: [],
+  };
+}
+
+/**
+ * Converts a parsed Croissant profile into one preview entry per file, with the
+ * UI-ready `FilePreviewDataUnion`. Tabular content (columns/rows/statistics) is
+ * derived from the profile; JSON text and PDF bytes are fetched separately on
+ * node click (their `content`/`fileUrl` are left empty here).
+ */
+export function buildFilePreviews(raw: unknown): FilePreviewEntry[] {
+  const profile = parseProfileRaw(raw);
+  if (!profile) return [];
+
+  const distributions = Array.isArray(profile.distribution)
+    ? profile.distribution
+    : [];
+  const entries: FilePreviewEntry[] = [];
+
+  for (const distribution of distributions) {
+    const id = distribution["@id"];
+    if (!id) continue;
+    const name = distribution.name ?? "";
+    const mime = distribution.encodingFormat;
+    const fileSize = distribution.contentSize ?? "";
+
+    let data: FilePreviewDataUnion;
+    if (mime === "application/pdf") {
+      data = {
+        type: "pdf",
+        filename: name,
+        fileSize,
+        description: "",
+        fileUrl: "",
+        totalPages: 0,
+      };
+    } else if (mime && JSON_MIMES.has(mime)) {
+      data = {
+        type: "json",
+        filename: name,
+        fileSize,
+        description: "",
+        content: "",
+      };
+    } else if (mime && TABULAR_MIMES.has(mime)) {
+      const recordSet = recordSetForFile(profile, id);
+      data = recordSet
+        ? buildTabular(recordSet, distribution)
+        : {
+            type: "tabular",
+            filename: name,
+            fileSize,
+            description: "",
+            columns: [],
+            rows: [],
+            totalRows: 0,
+            statistics: [],
+            dataQuality: [],
+          };
+    } else {
+      continue;
+    }
+
+    entries.push({ id, name, mimeType: mime, data });
+  }
+
+  return entries;
+}

--- a/tests/datasetProfile.test.ts
+++ b/tests/datasetProfile.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildFilePreviews,
+  mapFieldStatistics,
+  parseProfileRaw,
+  transposeSamplesToRows,
+} from "../src/lib/datasetProfile";
+
+// Trimmed but structurally-real MOMA Croissant profile (per dg-dataset-profiler
+// docs/profile-examples-moma.md): distribution = files, recordSet.field = columns
+// with per-column `sample` arrays and `dg:` statistics.
+const PROFILE = {
+  distribution: [
+    {
+      "@type": "cr:FileObject",
+      "@id": "f1",
+      name: "weather.csv",
+      contentSize: "65040 B",
+      encodingFormat: "text/csv",
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "f2",
+      name: "notes.pdf",
+      encodingFormat: "application/pdf",
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "f3",
+      name: "meta.json",
+      encodingFormat: "application/json",
+    },
+  ],
+  recordSet: [
+    {
+      "@type": "cr:RecordSet",
+      "@id": "rs1",
+      name: "weather",
+      field: [
+        {
+          "@type": "cr:Field",
+          "@id": "c1",
+          name: "station_id",
+          description: "ID",
+          dataType: "sc:Text",
+          source: {
+            fileObject: { "@id": "f1" },
+            extract: { column: "station_id" },
+          },
+          sample: ["A", "B", "C"],
+          statistics: {
+            rowCount: 1447,
+            missingCount: 0,
+            missingPercentage: 0,
+            uniqueCount: 3,
+          },
+        },
+        {
+          "@type": "cr:Field",
+          "@id": "c2",
+          name: "temperature",
+          description: "Air temperature",
+          dataType: "sc:Float",
+          source: {
+            fileObject: { "@id": "f1" },
+            extract: { column: "temperature" },
+          },
+          sample: [12.5, 13, 11.2],
+          statistics: {
+            rowCount: 1447,
+            mean: 12.2,
+            median: 12.5,
+            standardDeviation: 0.9,
+            min: 11.2,
+            max: 13,
+            missingCount: 333,
+            missingPercentage: 23,
+            uniqueCount: 100,
+            histogram:
+              '[{"binRange":[11,12],"count":5},{"binRange":[12,13],"count":7}]',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+test("parseProfileRaw accepts a JSON string or object and rejects junk", () => {
+  assert.equal(parseProfileRaw(null), null);
+  assert.equal(parseProfileRaw("not json"), null);
+  assert.deepEqual(parseProfileRaw('{"recordSet":[]}'), { recordSet: [] });
+  const obj = { recordSet: [] };
+  assert.equal(parseProfileRaw(obj), obj);
+});
+
+test("transposeSamplesToRows converts column-major samples into row objects", () => {
+  const rows = transposeSamplesToRows([
+    { "@id": "c1", sample: [1, 2, 3] },
+    { "@id": "c2", sample: ["x", "y", "z"] },
+  ]);
+  assert.equal(rows.length, 3);
+  assert.deepEqual(
+    rows[0].cells.map((c) => [c.columnId, c.value]),
+    [
+      ["c1", 1],
+      ["c2", "x"],
+    ],
+  );
+});
+
+test("transposeSamplesToRows caps rows at the given limit", () => {
+  const fields = [
+    { "@id": "c1", sample: Array.from({ length: 250 }, (_, i) => i) },
+  ];
+  assert.equal(transposeSamplesToRows(fields, 100).length, 100);
+});
+
+test("mapFieldStatistics maps dg fields and parses the histogram string", () => {
+  const stats = mapFieldStatistics(PROFILE.recordSet[0].field[1]);
+  assert.equal(stats.columnId, "c2");
+  assert.equal(stats.mean, 12.2);
+  assert.equal(stats.stdDev, 0.9);
+  assert.equal(stats.nullCount, 333);
+  assert.equal(stats.missingPercentage, 23);
+  assert.equal(stats.uniqueValues, 100);
+  assert.deepEqual(stats.distribution, [5, 7]);
+});
+
+test("buildFilePreviews builds a tabular preview for a recordSet file", () => {
+  const csv = buildFilePreviews(PROFILE).find((p) => p.id === "f1");
+  assert.ok(csv);
+  assert.equal(csv.mimeType, "text/csv");
+  assert.equal(csv.data.type, "tabular");
+  if (csv.data.type !== "tabular") return;
+  assert.deepEqual(
+    csv.data.columns.map((c) => c.name),
+    ["station_id", "temperature"],
+  );
+  assert.equal(csv.data.columns[0].type, "categorical");
+  assert.equal(csv.data.columns[1].type, "numeric");
+  assert.equal(csv.data.rows.length, 3);
+  assert.equal(csv.data.totalRows, 1447);
+  assert.equal(csv.data.totalMissingPercentage, 11.5);
+  assert.equal(csv.data.statistics.length, 2);
+});
+
+test("buildFilePreviews classifies pdf and json files by mime type", () => {
+  const previews = buildFilePreviews(PROFILE);
+  assert.equal(previews.find((p) => p.id === "f2")?.data.type, "pdf");
+  assert.equal(previews.find((p) => p.id === "f3")?.data.type, "json");
+});


### PR DESCRIPTION
Closes #162

## Summary
Replaces the hardcoded mock data in the Dataset Details **Preview** and **Statistics** tabs with real data from the MOMA dataset profile (`profileRaw`). The whole presentation layer already existed (`FilePreview/*` with the mime-type switcher, `ShowColumnsModal`, `StatisticsTab`, viewers) — this wires it to the backend.

## The contract
`profileRaw` is **Croissant JSON-LD** with a DataGEMS `dg:` extension (confirmed from the producing service, `dg-dataset-profiler`, `docs/profile-examples-moma.md`). The issue's field shorthand maps to:

| Issue | Real `profileRaw` |
|---|---|
| mime_type | `distribution[].encodingFormat` |
| file tree | `distribution[]` |
| columns | `recordSet[].field[]` (`name`/`description`/`dataType`) |
| rows | transposed `field[].sample[]` (column-major) |
| statistics | `field[].statistics` (`dg:ColumnStatistics`) |
| total_rows | `statistics.rowCount` |
| file_null_percentage | mean of column `missingPercentage` |

## Changes
- **`lib/datasetProfile.ts`** (TDD, 6 Node tests) — Croissant → `FilePreviewDataUnion`: tree+mime, columns, transposed rows, statistics (+ histogram string parsed for `MiniHistogram`).
- **`useApi`** — `getDatasetById` (GET `/api/dataset/{id}`, requests `profileRaw`) + `downloadDatasetFile` (GET `/api/storage/download/dataset/{id}/file-object/{nodeId}`).
- **`datasets/[id]` page** — requests `profileRaw`, threads it through `DatasetPlus`.
- **`DatasetDetailsPageContent`** — builds previews from `profileRaw`; real file tree; **fetches JSON (150 lines) / PDF (blob) on node click** (bandwidth-efficient); preview skeleton while loading. Drops `mockFileMap`/`getFilePreviewData`.
- **`PdfFilePreview`** — derives page count from the loaded document (`onLoadSuccess`) so the 3-pages + "remaining pages" overlay works (`profileRaw` carries no page count).

Tabular preview, statistics, and Show-Columns selection were already wired inside `FilePreview` and need no changes — the parser output matches its props.

## Acceptance criteria
- **Data fetching + loading** — `GET /api/dataset/{id}` (id from URL); dataset-level spinner covers profile load; skeleton for JSON/PDF content fetch.
- **CSV/Excel** — first 100 rows; columns drive `ShowColumnsModal`.
- **JSON** — first 150 lines. **PDF** — first 3 pages + 4th-page overlay.
- **Dynamic rendering by mime** — already in `FilePreview`; `type` now set from `encodingFormat`.
- **Efficiency** — content fetched only on node click.
- **Statistics** — global summary (Total rows / Missing values); per-column boxes; renders only Show-Columns–selected columns; empty/N-A handled by the existing components.

## Verification
- `pnpm test` (Node gate): **100/100** (6 new parser tests). `lint:biome:check` + `type-check`: clean.
- `test:unit`: unchanged vs `develop` baseline (61/13); zero new failures; none in touched areas.

## Caveats for review (not verified against live data — app requires Keycloak login)
1. **Flat file tree** — one node per `distribution` entry; nested `cr:FileSet`/`includes` folders aren't grouped yet.
2. **"Missing values"** = mean of per-column `missingPercentage` (no file-level value in the profile).
3. First real dataset load is worth eyeballing once available in an authed env.