### PR TITLE
DG-162 | Rewrite dataset-preview parser for the gateway's real node-graph profileRaw

### DIFF
--- a/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
+++ b/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
@@ -8,7 +8,11 @@ import { APP_ROUTES } from "@/config/appUrls";
 import { getDisplayCategory } from "@/config/collectionConstants";
 import type { DatasetPlus } from "@/data/dataset";
 import { useApi } from "@/hooks/useApi";
-import { buildFilePreviews } from "@/lib/datasetProfile";
+import {
+  buildFilePreviews,
+  buildFileTree,
+  type ProfileTreeNode,
+} from "@/lib/datasetProfile";
 import { logError } from "@/lib/logger";
 import { getNavigationUrl } from "@/lib/utils";
 import type { FilePreviewDataUnion } from "@/types/filePreview";
@@ -36,6 +40,24 @@ function extensionFromMime(mime?: string): string | undefined {
   return undefined;
 }
 
+function mapTreeToFileNodes(nodes: ProfileTreeNode[]): FileNode[] {
+  return nodes.map((node) =>
+    node.kind === "folder"
+      ? {
+          id: node.id,
+          name: node.name,
+          type: "folder",
+          children: mapTreeToFileNodes(node.children ?? []),
+        }
+      : {
+          id: node.id,
+          name: node.name,
+          type: "file",
+          extension: extensionFromMime(node.mimeType),
+        },
+  );
+}
+
 interface DatasetDetailsPageContentProps {
   dataset: DatasetPlus;
   returnToRoles?: boolean;
@@ -54,14 +76,8 @@ export default function DatasetDetailsPageContent({
   );
 
   const fileNodes: FileNode[] = useMemo(
-    () =>
-      previewEntries.map((entry) => ({
-        id: entry.id,
-        name: entry.name,
-        type: "file",
-        extension: extensionFromMime(entry.mimeType),
-      })),
-    [previewEntries],
+    () => mapTreeToFileNodes(buildFileTree(dataset.profileRaw)),
+    [dataset.profileRaw],
   );
 
   const [selectedFileId, setSelectedFileId] = useState<string | null>(null);

--- a/src/lib/datasetProfile.ts
+++ b/src/lib/datasetProfile.ts
@@ -6,46 +6,38 @@ import type {
 } from "@/types/filePreview";
 
 /**
- * Minimal shapes for the MOMA dataset profile (`profileRaw`), which is
- * Croissant JSON-LD with a DataGEMS `dg:` extension. See
- * datagems-eosc/dg-dataset-profiler docs/profile-examples-moma.md.
+ * The gateway returns `profileRaw` (MOMA profile) as a property graph:
+ * `nodes` carry `labels` + `properties`, and `edges` are typed relationships
+ * `{ from, to, labels: [type] }`. Verified against a live GET /api/dataset/{id}.
+ *
+ * Node labels: sc:Dataset, cr:FileObject (files), cr:Field (columns),
+ * cr:RecordSet (holds `examples` = stringified column->values), and
+ * dg:ColumnStatistics. Edge types: distribution (dataset->file),
+ * recordSet (dataset->recordSet), field (recordSet->column),
+ * source/fileObject (column->file), statistics (column->stats).
  */
-interface CroissantStatistics {
-  rowCount?: number | null;
-  mean?: number | null;
-  median?: number | null;
-  standardDeviation?: number | null;
-  min?: number | string | null;
-  max?: number | string | null;
-  missingCount?: number | null;
-  missingPercentage?: number | null;
-  uniqueCount?: number | null;
-  histogram?: string | null;
+interface GraphNode {
+  id?: string;
+  labels?: string[];
+  properties?: Record<string, unknown>;
 }
 
-interface CroissantField {
-  "@id"?: string;
-  name?: string;
-  description?: string;
-  dataType?: string;
-  source?: { fileObject?: { "@id"?: string } };
-  sample?: unknown[];
-  statistics?: CroissantStatistics;
+interface GraphEdge {
+  from?: string;
+  to?: string;
+  labels?: string[];
 }
 
-interface CroissantRecordSet {
-  "@id"?: string;
-  name?: string;
-  field?: CroissantField[];
+export interface ProfileGraph {
+  nodes?: GraphNode[];
+  edges?: GraphEdge[];
 }
 
-interface CroissantDistribution {
-  "@id"?: string;
-  "@type"?: string;
-  name?: string;
-  contentSize?: string;
-  encodingFormat?: string;
-  containedIn?: { "@id"?: string } | null;
+export interface FilePreviewEntry {
+  id: string; // FileObject node id — the fileObjectNodeId used for download
+  name: string;
+  mimeType?: string;
+  data: FilePreviewDataUnion;
 }
 
 export interface ProfileTreeNode {
@@ -56,17 +48,13 @@ export interface ProfileTreeNode {
   children?: ProfileTreeNode[];
 }
 
-export interface CroissantProfile {
-  distribution?: CroissantDistribution[];
-  recordSet?: CroissantRecordSet[];
-}
+const LABEL_FILE = "cr:FileObject";
+const LABEL_FIELD = "cr:Field";
+const LABEL_RECORDSET = "cr:RecordSet";
 
-export interface FilePreviewEntry {
-  id: string; // distribution @id — the fileObjectNodeId used for download
-  name: string;
-  mimeType?: string;
-  data: FilePreviewDataUnion;
-}
+const EDGE_FIELD = "field";
+const EDGE_SOURCE = "source/fileObject";
+const EDGE_STATISTICS = "statistics";
 
 const NUMERIC_TYPES = new Set([
   "sc:Integer",
@@ -75,46 +63,47 @@ const NUMERIC_TYPES = new Set([
   "sc:Decimal",
   "sc:Long",
 ]);
-
-const TABULAR_MIMES = new Set([
-  "text/csv",
-  "text/tab-separated-values",
-  "application/vnd.ms-excel",
-  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-]);
-
 const JSON_MIMES = new Set(["application/json", "application/x-ipynb+json"]);
-
-// Distribution entries that represent containers (folders) rather than files.
-const FOLDER_TYPES = new Set(["cr:FileSet", "dg:DatabaseConnection"]);
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function parseProfileRaw(raw: unknown): CroissantProfile | null {
-  if (raw == null) return null;
+export function parseProfileRaw(raw: unknown): ProfileGraph | null {
+  let value: unknown = raw;
   if (typeof raw === "string") {
     try {
-      const parsed = JSON.parse(raw);
-      return isObject(parsed) ? (parsed as CroissantProfile) : null;
+      value = JSON.parse(raw);
     } catch {
       return null;
     }
   }
-  return isObject(raw) ? (raw as CroissantProfile) : null;
+  if (isObject(value) && Array.isArray((value as ProfileGraph).nodes)) {
+    return value as ProfileGraph;
+  }
+  return null;
 }
 
-function mapColumnType(dataType?: string): FileColumn["type"] {
-  if (!dataType) return "categorical";
+function hasLabel(node: GraphNode, label: string): boolean {
+  return Array.isArray(node.labels) && node.labels.includes(label);
+}
+
+function edgeType(edge: GraphEdge): string {
+  return Array.isArray(edge.labels) && edge.labels.length > 0
+    ? edge.labels[0]
+    : "";
+}
+
+function mapColumnType(dataType: unknown): FileColumn["type"] {
+  if (typeof dataType !== "string") return "categorical";
   if (NUMERIC_TYPES.has(dataType)) return "numeric";
   if (dataType === "sc:Boolean") return "boolean";
   if (dataType === "sc:Date" || dataType === "sc:DateTime") return "date";
   return "categorical";
 }
 
-function parseHistogram(histogram?: string | null): number[] | undefined {
-  if (!histogram) return undefined;
+function parseHistogram(histogram: unknown): number[] | undefined {
+  if (typeof histogram !== "string") return undefined;
   try {
     const bins = JSON.parse(histogram);
     if (!Array.isArray(bins)) return undefined;
@@ -127,26 +116,38 @@ function parseHistogram(histogram?: string | null): number[] | undefined {
   }
 }
 
-export function mapFieldStatistics(field: CroissantField): ColumnStatistics {
-  const source = field.statistics ?? {};
-  const stat: ColumnStatistics = {
-    columnId: field["@id"] ?? field.name ?? "",
-  };
-  if (typeof source.uniqueCount === "number")
-    stat.uniqueValues = source.uniqueCount;
-  if (typeof source.missingCount === "number")
-    stat.nullCount = source.missingCount;
-  if (source.min != null) stat.min = source.min;
-  if (source.max != null) stat.max = source.max;
-  if (typeof source.mean === "number") stat.mean = source.mean;
-  if (typeof source.median === "number") stat.median = source.median;
-  if (typeof source.standardDeviation === "number") {
-    stat.stdDev = source.standardDeviation;
+function mapColumnStatistics(
+  columnId: string,
+  props: Record<string, unknown> | undefined,
+): ColumnStatistics {
+  const stat: ColumnStatistics = { columnId };
+  if (!props) return stat;
+  const num = (key: string) =>
+    typeof props[key] === "number" ? (props[key] as number) : undefined;
+
+  if (num("uniqueCount") !== undefined) stat.uniqueValues = num("uniqueCount");
+  if (num("missingCount") !== undefined) stat.nullCount = num("missingCount");
+  if (num("mean") !== undefined) stat.mean = num("mean");
+  if (num("median") !== undefined) stat.median = num("median");
+  if (num("standardDeviation") !== undefined) {
+    stat.stdDev = num("standardDeviation");
   }
-  if (typeof source.missingPercentage === "number") {
-    stat.missingPercentage = source.missingPercentage;
+  if (num("missingPercentage") !== undefined) {
+    stat.missingPercentage = num("missingPercentage");
   }
-  const distribution = parseHistogram(source.histogram);
+  if (
+    props.min != null &&
+    (typeof props.min === "number" || typeof props.min === "string")
+  ) {
+    stat.min = props.min;
+  }
+  if (
+    props.max != null &&
+    (typeof props.max === "number" || typeof props.max === "string")
+  ) {
+    stat.max = props.max;
+  }
+  const distribution = parseHistogram(props.histogram);
   if (distribution) stat.distribution = distribution;
   return stat;
 }
@@ -163,65 +164,98 @@ function normalizeCell(value: unknown): string | number | boolean | null {
   return String(value);
 }
 
-export function transposeSamplesToRows(
-  fields: { "@id"?: string; sample?: unknown[] }[],
-  limit = 100,
+interface GraphIndex {
+  nodeById: Map<string, GraphNode>;
+  targetsOf: (fromId: string, type: string) => string[];
+}
+
+function indexGraph(graph: ProfileGraph): GraphIndex {
+  const nodeById = new Map<string, GraphNode>();
+  for (const node of graph.nodes ?? []) {
+    if (node.id) nodeById.set(node.id, node);
+  }
+  const edges = graph.edges ?? [];
+  return {
+    nodeById,
+    targetsOf: (fromId, type) =>
+      edges
+        .filter((e) => e.from === fromId && edgeType(e) === type && e.to)
+        .map((e) => e.to as string),
+  };
+}
+
+function buildRows(
+  recordSet: GraphNode | undefined,
+  columns: GraphNode[],
 ): FileRow[] {
+  const rawExamples = recordSet?.properties?.examples;
+  if (typeof rawExamples !== "string") return [];
+  let examples: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(rawExamples);
+    if (!isObject(parsed)) return [];
+    examples = parsed;
+  } catch {
+    return [];
+  }
+
+  const columnValues = columns.map((column) => {
+    const name = String(column.properties?.name ?? "");
+    const values = examples[name];
+    return Array.isArray(values) ? values : [];
+  });
+
   const rowCount = Math.min(
-    limit,
-    fields.reduce((max, field) => Math.max(max, field.sample?.length ?? 0), 0),
+    100,
+    columnValues.reduce((max, values) => Math.max(max, values.length), 0),
   );
+
   const rows: FileRow[] = [];
   for (let index = 0; index < rowCount; index++) {
     rows.push({
       id: String(index),
-      cells: fields.map((field) => ({
-        columnId: field["@id"] ?? "",
-        value: normalizeCell(field.sample?.[index]),
+      cells: columns.map((column, columnIndex) => ({
+        columnId: column.id ?? "",
+        value: normalizeCell(columnValues[columnIndex][index]),
       })),
     });
   }
   return rows;
 }
 
-function recordSetForFile(
-  profile: CroissantProfile,
-  fileId: string,
-): CroissantRecordSet | undefined {
-  return profile.recordSet?.find((recordSet) =>
-    recordSet.field?.some(
-      (field) => field.source?.fileObject?.["@id"] === fileId,
-    ),
-  );
-}
-
 function buildTabular(
-  recordSet: CroissantRecordSet,
-  distribution: CroissantDistribution,
+  file: GraphNode,
+  columns: GraphNode[],
+  recordSet: GraphNode | undefined,
+  index: GraphIndex,
 ): FilePreviewDataUnion {
-  const fields = recordSet.field ?? [];
-  const columns: FileColumn[] = fields.map((field) => ({
-    id: field["@id"] ?? field.name ?? "",
-    name: field.name ?? "",
-    type: mapColumnType(field.dataType),
-    visible: true,
-    description: field.description || undefined,
-  }));
-  const rows = transposeSamplesToRows(fields);
-  const statistics = fields.map(mapFieldStatistics);
+  const statsProps = (columnId: string) => {
+    const statsId = index.targetsOf(columnId, EDGE_STATISTICS)[0];
+    return statsId ? index.nodeById.get(statsId)?.properties : undefined;
+  };
 
-  const rowCounts = fields
-    .map((field) => field.statistics?.rowCount)
+  const uiColumns: FileColumn[] = columns.map((column) => ({
+    id: column.id ?? "",
+    name: String(column.properties?.name ?? ""),
+    type: mapColumnType(column.properties?.dataType),
+    visible: true,
+    description: (column.properties?.description as string) || undefined,
+  }));
+
+  const statistics = columns.map((column) =>
+    mapColumnStatistics(column.id ?? "", statsProps(column.id ?? "")),
+  );
+  const rows = buildRows(recordSet, columns);
+
+  const rowCounts = columns
+    .map((column) => statsProps(column.id ?? "")?.rowCount)
     .filter((count): count is number => typeof count === "number");
   const totalRows = rowCounts.length > 0 ? rowCounts[0] : rows.length;
 
-  // File-level "missing values" = all missing cells / all cells. Equivalent to
-  // the mean of per-column percentages when every column shares a row count,
-  // but robust when they differ.
-  const missingCounts = fields
-    .map((field) => field.statistics?.missingCount)
+  const missingCounts = columns
+    .map((column) => statsProps(column.id ?? "")?.missingCount)
     .filter((count): count is number => typeof count === "number");
-  const totalCells = totalRows * fields.length;
+  const totalCells = totalRows * columns.length;
   const totalMissingPercentage =
     missingCounts.length > 0 && totalCells > 0
       ? (missingCounts.reduce((sum, count) => sum + count, 0) / totalCells) *
@@ -230,10 +264,10 @@ function buildTabular(
 
   return {
     type: "tabular",
-    filename: distribution.name ?? recordSet.name ?? "",
-    fileSize: distribution.contentSize ?? "",
+    filename: String(file.properties?.name ?? ""),
+    fileSize: String(file.properties?.contentSize ?? ""),
     description: "",
-    columns,
+    columns: uiColumns,
     rows,
     totalRows,
     totalMissingPercentage,
@@ -243,35 +277,65 @@ function buildTabular(
 }
 
 /**
- * Converts a parsed Croissant profile into one preview entry per file, with the
- * UI-ready `FilePreviewDataUnion`. Tabular content (columns/rows/statistics) is
- * derived from the profile; JSON text and PDF bytes are fetched separately on
- * node click (their `content`/`fileUrl` are left empty here).
+ * Converts the profile graph into one preview entry per file. Tabular content
+ * (columns/rows/statistics) is derived from the graph; JSON text and PDF bytes
+ * are fetched separately on node click (their `content`/`fileUrl` stay empty).
  */
 export function buildFilePreviews(raw: unknown): FilePreviewEntry[] {
-  const profile = parseProfileRaw(raw);
-  if (!profile) return [];
+  const graph = parseProfileRaw(raw);
+  if (!graph) return [];
+  const index = indexGraph(graph);
+  const nodes = graph.nodes ?? [];
 
-  const distributions = Array.isArray(profile.distribution)
-    ? profile.distribution
-    : [];
+  const recordSets = nodes.filter((node) => hasLabel(node, LABEL_RECORDSET));
+  const files = nodes.filter((node) => hasLabel(node, LABEL_FILE));
   const entries: FilePreviewEntry[] = [];
 
-  for (const distribution of distributions) {
-    // Folders (FileSets / database connections) are not previewable files.
-    if (FOLDER_TYPES.has(distribution["@type"] ?? "")) continue;
-    const id = distribution["@id"];
-    if (!id) continue;
-    const name = distribution.name ?? "";
-    const mime = distribution.encodingFormat;
-    const fileSize = distribution.contentSize ?? "";
+  const fileOfColumn = (columnId: string) =>
+    index.targetsOf(columnId, EDGE_SOURCE)[0];
+
+  for (const file of files) {
+    const fileId = file.id;
+    if (!fileId) continue;
+    const name = String(file.properties?.name ?? "");
+    const mime =
+      typeof file.properties?.encodingFormat === "string"
+        ? (file.properties.encodingFormat as string)
+        : undefined;
+
+    const recordSet = recordSets.find((rs) =>
+      index
+        .targetsOf(rs.id ?? "", EDGE_FIELD)
+        .some((columnId) => fileOfColumn(columnId) === fileId),
+    );
+
+    let columns: GraphNode[] = [];
+    if (recordSet) {
+      columns = index
+        .targetsOf(recordSet.id ?? "", EDGE_FIELD)
+        .map((columnId) => index.nodeById.get(columnId))
+        .filter(
+          (node): node is GraphNode =>
+            !!node &&
+            hasLabel(node, LABEL_FIELD) &&
+            (fileOfColumn(node.id ?? "") === fileId ||
+              fileOfColumn(node.id ?? "") === undefined),
+        );
+    } else {
+      columns = nodes.filter(
+        (node) =>
+          hasLabel(node, LABEL_FIELD) && fileOfColumn(node.id ?? "") === fileId,
+      );
+    }
 
     let data: FilePreviewDataUnion;
-    if (mime === "application/pdf") {
+    if (columns.length > 0) {
+      data = buildTabular(file, columns, recordSet, index);
+    } else if (mime === "application/pdf") {
       data = {
         type: "pdf",
         filename: name,
-        fileSize,
+        fileSize: String(file.properties?.contentSize ?? ""),
         description: "",
         fileUrl: "",
         totalPages: 0,
@@ -280,88 +344,37 @@ export function buildFilePreviews(raw: unknown): FilePreviewEntry[] {
       data = {
         type: "json",
         filename: name,
-        fileSize,
+        fileSize: String(file.properties?.contentSize ?? ""),
         description: "",
         content: "",
       };
-    } else if (mime && TABULAR_MIMES.has(mime)) {
-      const recordSet = recordSetForFile(profile, id);
-      data = recordSet
-        ? buildTabular(recordSet, distribution)
-        : {
-            type: "tabular",
-            filename: name,
-            fileSize,
-            description: "",
-            columns: [],
-            rows: [],
-            totalRows: 0,
-            statistics: [],
-            dataQuality: [],
-          };
     } else {
       continue;
     }
 
-    entries.push({ id, name, mimeType: mime, data });
+    entries.push({ id: fileId, name, mimeType: mime, data });
   }
 
   return entries;
 }
 
 /**
- * Builds the nested file tree from the profile's `distribution`: `cr:FileSet`
- * entries are folders, `cr:FileObject` entries are files nested under their
- * `containedIn` folder (or at the root when they have none).
+ * Builds the file tree from the graph's FileObject nodes. (Datasets observed
+ * so far are flat; folder grouping would require folder-typed nodes/edges,
+ * not yet seen in the live graph.)
  */
 export function buildFileTree(raw: unknown): ProfileTreeNode[] {
-  const profile = parseProfileRaw(raw);
-  if (!profile) return [];
-
-  const distributions = Array.isArray(profile.distribution)
-    ? profile.distribution
-    : [];
-
-  const folders = new Map<string, ProfileTreeNode>();
-  for (const distribution of distributions) {
-    const id = distribution["@id"];
-    if (id && FOLDER_TYPES.has(distribution["@type"] ?? "")) {
-      folders.set(id, {
-        id,
-        name: distribution.name ?? "",
-        kind: "folder",
-        children: [],
-      });
-    }
-  }
-
-  const roots: ProfileTreeNode[] = [];
-  for (const distribution of distributions) {
-    const id = distribution["@id"];
-    if (!id) continue;
-
-    let node: ProfileTreeNode | undefined;
-    if (FOLDER_TYPES.has(distribution["@type"] ?? "")) {
-      node = folders.get(id);
-    } else {
-      node = {
-        id,
-        name: distribution.name ?? "",
-        kind: "file",
-        mimeType: distribution.encodingFormat,
-      };
-    }
-    if (!node) continue;
-
-    const parentId = distribution.containedIn?.["@id"];
-    const parent =
-      parentId && parentId !== id ? folders.get(parentId) : undefined;
-    if (parent) {
-      parent.children?.push(node);
-    } else {
-      roots.push(node);
-    }
-  }
-
-  return roots;
+  const graph = parseProfileRaw(raw);
+  if (!graph) return [];
+  return (graph.nodes ?? [])
+    .filter((node) => hasLabel(node, LABEL_FILE) && node.id)
+    .map((node) => ({
+      id: node.id as string,
+      name: String(node.properties?.name ?? ""),
+      kind: "file" as const,
+      mimeType:
+        typeof node.properties?.encodingFormat === "string"
+          ? (node.properties.encodingFormat as string)
+          : undefined,
+    }));
 }

--- a/src/lib/datasetProfile.ts
+++ b/src/lib/datasetProfile.ts
@@ -41,9 +41,19 @@ interface CroissantRecordSet {
 
 interface CroissantDistribution {
   "@id"?: string;
+  "@type"?: string;
   name?: string;
   contentSize?: string;
   encodingFormat?: string;
+  containedIn?: { "@id"?: string } | null;
+}
+
+export interface ProfileTreeNode {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  mimeType?: string;
+  children?: ProfileTreeNode[];
 }
 
 export interface CroissantProfile {
@@ -202,13 +212,17 @@ function buildTabular(
     .filter((count): count is number => typeof count === "number");
   const totalRows = rowCounts.length > 0 ? rowCounts[0] : rows.length;
 
-  const missingPercentages = fields
-    .map((field) => field.statistics?.missingPercentage)
-    .filter((value): value is number => typeof value === "number");
+  // File-level "missing values" = all missing cells / all cells. Equivalent to
+  // the mean of per-column percentages when every column shares a row count,
+  // but robust when they differ.
+  const missingCounts = fields
+    .map((field) => field.statistics?.missingCount)
+    .filter((count): count is number => typeof count === "number");
+  const totalCells = totalRows * fields.length;
   const totalMissingPercentage =
-    missingPercentages.length > 0
-      ? missingPercentages.reduce((sum, value) => sum + value, 0) /
-        missingPercentages.length
+    missingCounts.length > 0 && totalCells > 0
+      ? (missingCounts.reduce((sum, count) => sum + count, 0) / totalCells) *
+        100
       : undefined;
 
   return {
@@ -241,6 +255,8 @@ export function buildFilePreviews(raw: unknown): FilePreviewEntry[] {
   const entries: FilePreviewEntry[] = [];
 
   for (const distribution of distributions) {
+    // FileSets are folders, not previewable files.
+    if (distribution["@type"] === "cr:FileSet") continue;
     const id = distribution["@id"];
     if (!id) continue;
     const name = distribution.name ?? "";
@@ -288,4 +304,61 @@ export function buildFilePreviews(raw: unknown): FilePreviewEntry[] {
   }
 
   return entries;
+}
+
+/**
+ * Builds the nested file tree from the profile's `distribution`: `cr:FileSet`
+ * entries are folders, `cr:FileObject` entries are files nested under their
+ * `containedIn` folder (or at the root when they have none).
+ */
+export function buildFileTree(raw: unknown): ProfileTreeNode[] {
+  const profile = parseProfileRaw(raw);
+  if (!profile) return [];
+
+  const distributions = Array.isArray(profile.distribution)
+    ? profile.distribution
+    : [];
+
+  const folders = new Map<string, ProfileTreeNode>();
+  for (const distribution of distributions) {
+    const id = distribution["@id"];
+    if (distribution["@type"] === "cr:FileSet" && id) {
+      folders.set(id, {
+        id,
+        name: distribution.name ?? "",
+        kind: "folder",
+        children: [],
+      });
+    }
+  }
+
+  const roots: ProfileTreeNode[] = [];
+  for (const distribution of distributions) {
+    const id = distribution["@id"];
+    if (!id) continue;
+
+    let node: ProfileTreeNode | undefined;
+    if (distribution["@type"] === "cr:FileSet") {
+      node = folders.get(id);
+    } else {
+      node = {
+        id,
+        name: distribution.name ?? "",
+        kind: "file",
+        mimeType: distribution.encodingFormat,
+      };
+    }
+    if (!node) continue;
+
+    const parentId = distribution.containedIn?.["@id"];
+    const parent =
+      parentId && parentId !== id ? folders.get(parentId) : undefined;
+    if (parent) {
+      parent.children?.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  return roots;
 }

--- a/src/lib/datasetProfile.ts
+++ b/src/lib/datasetProfile.ts
@@ -85,6 +85,9 @@ const TABULAR_MIMES = new Set([
 
 const JSON_MIMES = new Set(["application/json", "application/x-ipynb+json"]);
 
+// Distribution entries that represent containers (folders) rather than files.
+const FOLDER_TYPES = new Set(["cr:FileSet", "dg:DatabaseConnection"]);
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -255,8 +258,8 @@ export function buildFilePreviews(raw: unknown): FilePreviewEntry[] {
   const entries: FilePreviewEntry[] = [];
 
   for (const distribution of distributions) {
-    // FileSets are folders, not previewable files.
-    if (distribution["@type"] === "cr:FileSet") continue;
+    // Folders (FileSets / database connections) are not previewable files.
+    if (FOLDER_TYPES.has(distribution["@type"] ?? "")) continue;
     const id = distribution["@id"];
     if (!id) continue;
     const name = distribution.name ?? "";
@@ -322,7 +325,7 @@ export function buildFileTree(raw: unknown): ProfileTreeNode[] {
   const folders = new Map<string, ProfileTreeNode>();
   for (const distribution of distributions) {
     const id = distribution["@id"];
-    if (distribution["@type"] === "cr:FileSet" && id) {
+    if (id && FOLDER_TYPES.has(distribution["@type"] ?? "")) {
       folders.set(id, {
         id,
         name: distribution.name ?? "",
@@ -338,7 +341,7 @@ export function buildFileTree(raw: unknown): ProfileTreeNode[] {
     if (!id) continue;
 
     let node: ProfileTreeNode | undefined;
-    if (distribution["@type"] === "cr:FileSet") {
+    if (FOLDER_TYPES.has(distribution["@type"] ?? "")) {
       node = folders.get(id);
     } else {
       node = {

--- a/tests/datasetProfile.test.ts
+++ b/tests/datasetProfile.test.ts
@@ -3,245 +3,176 @@ import test from "node:test";
 import {
   buildFilePreviews,
   buildFileTree,
-  mapFieldStatistics,
   parseProfileRaw,
-  transposeSamplesToRows,
 } from "../src/lib/datasetProfile";
 
-// Trimmed but structurally-real MOMA Croissant profile (per dg-dataset-profiler
-// docs/profile-examples-moma.md): distribution = files, recordSet.field = columns
-// with per-column `sample` arrays and `dg:` statistics.
-const PROFILE = {
-  distribution: [
+// Mirrors the REAL gateway profileRaw: a { nodes, edges } graph
+// (per a live GET /api/dataset/{id}). Nodes carry labels + properties;
+// edges are typed relationships {from, to, labels:[type]}.
+const GRAPH = {
+  nodes: [
     {
-      "@type": "cr:FileObject",
-      "@id": "f1",
-      name: "weather.csv",
-      contentSize: "65040 B",
-      encodingFormat: "text/csv",
+      id: "ds",
+      labels: ["sc:Dataset"],
+      properties: { name: "zoo_tierarten_2024", status: "ready" },
     },
     {
-      "@type": "cr:FileObject",
-      "@id": "f2",
-      name: "notes.pdf",
-      encodingFormat: "application/pdf",
+      id: "file1",
+      labels: ["CSV", "Data", "cr:FileObject"],
+      properties: {
+        name: "zoo-2024.csv",
+        encodingFormat: "text/csv",
+        contentSize: "2407043 B",
+      },
     },
     {
-      "@type": "cr:FileObject",
-      "@id": "f3",
-      name: "meta.json",
-      encodingFormat: "application/json",
+      id: "col1",
+      labels: ["Column", "cr:Field"],
+      properties: {
+        name: "Kategorie",
+        dataType: "sc:Text",
+        description: "category",
+        sample: ["Amphibien", "Fische"],
+      },
+    },
+    {
+      id: "col2",
+      labels: ["Column", "cr:Field"],
+      properties: { name: "Anzahl", dataType: "sc:Integer", description: "" },
+    },
+    {
+      id: "rs",
+      labels: ["cr:RecordSet"],
+      properties: {
+        name: "zoo-2024",
+        examples: JSON.stringify({
+          Kategorie: ["Amphibien", "Fische", "Voegel"],
+          Anzahl: [3, 5, 7],
+        }),
+      },
+    },
+    {
+      id: "stat1",
+      labels: ["Statistics", "dg:ColumnStatistics"],
+      properties: {
+        rowCount: 192,
+        missingCount: 0,
+        missingPercentage: 0,
+        uniqueCount: 190,
+      },
+    },
+    {
+      id: "stat2",
+      labels: ["Statistics", "dg:ColumnStatistics"],
+      properties: {
+        rowCount: 192,
+        missingCount: 12,
+        missingPercentage: 6.25,
+        uniqueCount: 50,
+        mean: 4.2,
+        median: 4,
+        standardDeviation: 1.1,
+        min: 1,
+        max: 9,
+        histogram:
+          '[{"binRange":[1,5],"count":100},{"binRange":[5,9],"count":80}]',
+      },
     },
   ],
-  recordSet: [
-    {
-      "@type": "cr:RecordSet",
-      "@id": "rs1",
-      name: "weather",
-      field: [
-        {
-          "@type": "cr:Field",
-          "@id": "c1",
-          name: "station_id",
-          description: "ID",
-          dataType: "sc:Text",
-          source: {
-            fileObject: { "@id": "f1" },
-            extract: { column: "station_id" },
-          },
-          sample: ["A", "B", "C"],
-          statistics: {
-            rowCount: 1447,
-            missingCount: 0,
-            missingPercentage: 0,
-            uniqueCount: 3,
-          },
-        },
-        {
-          "@type": "cr:Field",
-          "@id": "c2",
-          name: "temperature",
-          description: "Air temperature",
-          dataType: "sc:Float",
-          source: {
-            fileObject: { "@id": "f1" },
-            extract: { column: "temperature" },
-          },
-          sample: [12.5, 13, 11.2],
-          statistics: {
-            rowCount: 1447,
-            mean: 12.2,
-            median: 12.5,
-            standardDeviation: 0.9,
-            min: 11.2,
-            max: 13,
-            missingCount: 333,
-            missingPercentage: 23,
-            uniqueCount: 100,
-            histogram:
-              '[{"binRange":[11,12],"count":5},{"binRange":[12,13],"count":7}]',
-          },
-        },
-      ],
-    },
+  edges: [
+    { from: "ds", to: "file1", labels: ["distribution"] },
+    { from: "ds", to: "rs", labels: ["recordSet"] },
+    { from: "rs", to: "col1", labels: ["field"] },
+    { from: "rs", to: "col2", labels: ["field"] },
+    { from: "col1", to: "file1", labels: ["source/fileObject"] },
+    { from: "col2", to: "file1", labels: ["source/fileObject"] },
+    { from: "col1", to: "stat1", labels: ["statistics"] },
+    { from: "col2", to: "stat2", labels: ["statistics"] },
   ],
 };
 
-test("parseProfileRaw accepts a JSON string or object and rejects junk", () => {
+test("parseProfileRaw accepts a {nodes} graph (object or JSON string), rejects junk", () => {
   assert.equal(parseProfileRaw(null), null);
-  assert.equal(parseProfileRaw("not json"), null);
-  assert.deepEqual(parseProfileRaw('{"recordSet":[]}'), { recordSet: [] });
-  const obj = { recordSet: [] };
-  assert.equal(parseProfileRaw(obj), obj);
+  assert.equal(parseProfileRaw("nope"), null);
+  assert.equal(parseProfileRaw({ foo: 1 }), null);
+  assert.ok(parseProfileRaw(GRAPH));
+  assert.ok(parseProfileRaw(JSON.stringify(GRAPH)));
 });
 
-test("transposeSamplesToRows converts column-major samples into row objects", () => {
-  const rows = transposeSamplesToRows([
-    { "@id": "c1", sample: [1, 2, 3] },
-    { "@id": "c2", sample: ["x", "y", "z"] },
-  ]);
-  assert.equal(rows.length, 3);
+test("buildFilePreviews builds a tabular preview for a CSV file from the graph", () => {
+  const file = buildFilePreviews(GRAPH).find((p) => p.id === "file1");
+  assert.ok(file);
+  assert.equal(file.mimeType, "text/csv");
+  assert.equal(file.data.type, "tabular");
+  if (file.data.type !== "tabular") return;
+
   assert.deepEqual(
-    rows[0].cells.map((c) => [c.columnId, c.value]),
-    [
-      ["c1", 1],
-      ["c2", "x"],
-    ],
+    file.data.columns.map((c) => c.name),
+    ["Kategorie", "Anzahl"],
   );
-});
+  assert.equal(file.data.columns[0].type, "categorical");
+  assert.equal(file.data.columns[1].type, "numeric");
+  assert.equal(file.data.columns[0].description, "category");
 
-test("transposeSamplesToRows caps rows at the given limit", () => {
-  const fields = [
-    { "@id": "c1", sample: Array.from({ length: 250 }, (_, i) => i) },
-  ];
-  assert.equal(transposeSamplesToRows(fields, 100).length, 100);
-});
-
-test("mapFieldStatistics maps dg fields and parses the histogram string", () => {
-  const stats = mapFieldStatistics(PROFILE.recordSet[0].field[1]);
-  assert.equal(stats.columnId, "c2");
-  assert.equal(stats.mean, 12.2);
-  assert.equal(stats.stdDev, 0.9);
-  assert.equal(stats.nullCount, 333);
-  assert.equal(stats.missingPercentage, 23);
-  assert.equal(stats.uniqueValues, 100);
-  assert.deepEqual(stats.distribution, [5, 7]);
-});
-
-test("buildFilePreviews builds a tabular preview for a recordSet file", () => {
-  const csv = buildFilePreviews(PROFILE).find((p) => p.id === "f1");
-  assert.ok(csv);
-  assert.equal(csv.mimeType, "text/csv");
-  assert.equal(csv.data.type, "tabular");
-  if (csv.data.type !== "tabular") return;
+  // rows come from the RecordSet examples (column-major -> row-major)
+  assert.equal(file.data.rows.length, 3);
   assert.deepEqual(
-    csv.data.columns.map((c) => c.name),
-    ["station_id", "temperature"],
+    file.data.rows[0].cells.map((cell) => cell.value),
+    ["Amphibien", 3],
   );
-  assert.equal(csv.data.columns[0].type, "categorical");
-  assert.equal(csv.data.columns[1].type, "numeric");
-  assert.equal(csv.data.rows.length, 3);
-  assert.equal(csv.data.totalRows, 1447);
-  // total missing cells / total cells = (0 + 333) / (1447 * 2) * 100
+
+  assert.equal(file.data.totalRows, 192);
+  assert.equal(file.data.statistics.length, 2);
+  // total missing cells / total cells = (0 + 12) / (192 * 2) * 100
   assert.ok(
-    Math.abs((csv.data.totalMissingPercentage ?? 0) - 11.5065) < 0.01,
-    `expected ~11.51, got ${csv.data.totalMissingPercentage}`,
-  );
-  assert.equal(csv.data.statistics.length, 2);
-});
-
-const TREE_PROFILE = {
-  distribution: [
-    {
-      "@type": "cr:FileObject",
-      "@id": "root.csv",
-      name: "root.csv",
-      encodingFormat: "text/csv",
-    },
-    { "@type": "cr:FileSet", "@id": "folderA", name: "PDFs" },
-    {
-      "@type": "cr:FileObject",
-      "@id": "a.pdf",
-      name: "a.pdf",
-      encodingFormat: "application/pdf",
-      containedIn: { "@id": "folderA" },
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "b.pdf",
-      name: "b.pdf",
-      encodingFormat: "application/pdf",
-      containedIn: { "@id": "folderA" },
-    },
-  ],
-};
-
-test("buildFileTree nests FileObjects under their containedIn FileSet", () => {
-  const tree = buildFileTree(TREE_PROFILE);
-  assert.equal(tree.length, 2);
-
-  const folder = tree.find((node) => node.id === "folderA");
-  assert.ok(folder);
-  assert.equal(folder.kind, "folder");
-  assert.deepEqual(
-    folder.children?.map((child) => child.id),
-    ["a.pdf", "b.pdf"],
-  );
-
-  const rootFile = tree.find((node) => node.id === "root.csv");
-  assert.equal(rootFile?.kind, "file");
-  assert.equal(rootFile?.mimeType, "text/csv");
-});
-
-test("buildFilePreviews skips FileSets — folders are not previewable", () => {
-  const previews = buildFilePreviews(TREE_PROFILE);
-  assert.deepEqual(previews.map((p) => p.id).sort(), [
-    "a.pdf",
-    "b.pdf",
-    "root.csv",
-  ]);
-});
-
-test("buildFilePreviews classifies pdf and json files by mime type", () => {
-  const previews = buildFilePreviews(PROFILE);
-  assert.equal(previews.find((p) => p.id === "f2")?.data.type, "pdf");
-  assert.equal(previews.find((p) => p.id === "f3")?.data.type, "json");
-});
-
-// Mirrors the real profiler output: a dg:DatabaseConnection whose tables
-// (text/sql FileObjects) reference it via containedIn.
-const DB_PROFILE = {
-  distribution: [
-    { "@type": "dg:DatabaseConnection", "@id": "db1", name: "ds_mathe" },
-    {
-      "@type": "cr:FileObject",
-      "@id": "t1",
-      name: "users",
-      encodingFormat: "text/sql",
-      containedIn: { "@id": "db1" },
-    },
-    {
-      "@type": "cr:FileObject",
-      "@id": "t2",
-      name: "roles",
-      encodingFormat: "text/sql",
-      containedIn: { "@id": "db1" },
-    },
-  ],
-};
-
-test("buildFileTree treats a DatabaseConnection as a folder of its tables", () => {
-  const tree = buildFileTree(DB_PROFILE);
-  assert.equal(tree.length, 1);
-  assert.equal(tree[0].kind, "folder");
-  assert.equal(tree[0].name, "ds_mathe");
-  assert.deepEqual(
-    tree[0].children?.map((child) => child.id),
-    ["t1", "t2"],
+    Math.abs((file.data.totalMissingPercentage ?? 0) - 3.125) < 0.001,
+    `got ${file.data.totalMissingPercentage}`,
   );
 });
 
-test("buildFilePreviews does not emit a DatabaseConnection container", () => {
-  const ids = buildFilePreviews(DB_PROFILE).map((p) => p.id);
-  assert.ok(!ids.includes("db1"));
+test("buildFilePreviews maps numeric column statistics incl. histogram", () => {
+  const file = buildFilePreviews(GRAPH).find((p) => p.id === "file1");
+  if (file?.data.type !== "tabular") throw new Error("expected tabular");
+  const anzahl = file.data.statistics.find((s) => s.columnId === "col2");
+  assert.ok(anzahl);
+  assert.equal(anzahl.mean, 4.2);
+  assert.equal(anzahl.stdDev, 1.1);
+  assert.equal(anzahl.min, 1);
+  assert.equal(anzahl.max, 9);
+  assert.equal(anzahl.nullCount, 12);
+  assert.equal(anzahl.uniqueValues, 50);
+  assert.deepEqual(anzahl.distribution, [100, 80]);
+});
+
+test("buildFileTree lists files from the graph", () => {
+  const tree = buildFileTree(GRAPH);
+  const file = tree.find((n) => n.id === "file1");
+  assert.ok(file);
+  assert.equal(file.kind, "file");
+  assert.equal(file.mimeType, "text/csv");
+});
+
+test("buildFilePreviews classifies pdf/json files with no columns by mime", () => {
+  const graph = {
+    nodes: [
+      { id: "ds", labels: ["sc:Dataset"], properties: { name: "d" } },
+      {
+        id: "p",
+        labels: ["cr:FileObject"],
+        properties: { name: "doc.pdf", encodingFormat: "application/pdf" },
+      },
+      {
+        id: "j",
+        labels: ["cr:FileObject"],
+        properties: { name: "meta.json", encodingFormat: "application/json" },
+      },
+    ],
+    edges: [
+      { from: "ds", to: "p", labels: ["distribution"] },
+      { from: "ds", to: "j", labels: ["distribution"] },
+    ],
+  };
+  const previews = buildFilePreviews(graph);
+  assert.equal(previews.find((p) => p.id === "p")?.data.type, "pdf");
+  assert.equal(previews.find((p) => p.id === "j")?.data.type, "json");
 });

--- a/tests/datasetProfile.test.ts
+++ b/tests/datasetProfile.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildFilePreviews,
+  buildFileTree,
   mapFieldStatistics,
   parseProfileRaw,
   transposeSamplesToRows,
@@ -141,8 +142,64 @@ test("buildFilePreviews builds a tabular preview for a recordSet file", () => {
   assert.equal(csv.data.columns[1].type, "numeric");
   assert.equal(csv.data.rows.length, 3);
   assert.equal(csv.data.totalRows, 1447);
-  assert.equal(csv.data.totalMissingPercentage, 11.5);
+  // total missing cells / total cells = (0 + 333) / (1447 * 2) * 100
+  assert.ok(
+    Math.abs((csv.data.totalMissingPercentage ?? 0) - 11.5065) < 0.01,
+    `expected ~11.51, got ${csv.data.totalMissingPercentage}`,
+  );
   assert.equal(csv.data.statistics.length, 2);
+});
+
+const TREE_PROFILE = {
+  distribution: [
+    {
+      "@type": "cr:FileObject",
+      "@id": "root.csv",
+      name: "root.csv",
+      encodingFormat: "text/csv",
+    },
+    { "@type": "cr:FileSet", "@id": "folderA", name: "PDFs" },
+    {
+      "@type": "cr:FileObject",
+      "@id": "a.pdf",
+      name: "a.pdf",
+      encodingFormat: "application/pdf",
+      containedIn: { "@id": "folderA" },
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "b.pdf",
+      name: "b.pdf",
+      encodingFormat: "application/pdf",
+      containedIn: { "@id": "folderA" },
+    },
+  ],
+};
+
+test("buildFileTree nests FileObjects under their containedIn FileSet", () => {
+  const tree = buildFileTree(TREE_PROFILE);
+  assert.equal(tree.length, 2);
+
+  const folder = tree.find((node) => node.id === "folderA");
+  assert.ok(folder);
+  assert.equal(folder.kind, "folder");
+  assert.deepEqual(
+    folder.children?.map((child) => child.id),
+    ["a.pdf", "b.pdf"],
+  );
+
+  const rootFile = tree.find((node) => node.id === "root.csv");
+  assert.equal(rootFile?.kind, "file");
+  assert.equal(rootFile?.mimeType, "text/csv");
+});
+
+test("buildFilePreviews skips FileSets — folders are not previewable", () => {
+  const previews = buildFilePreviews(TREE_PROFILE);
+  assert.deepEqual(previews.map((p) => p.id).sort(), [
+    "a.pdf",
+    "b.pdf",
+    "root.csv",
+  ]);
 });
 
 test("buildFilePreviews classifies pdf and json files by mime type", () => {

--- a/tests/datasetProfile.test.ts
+++ b/tests/datasetProfile.test.ts
@@ -207,3 +207,41 @@ test("buildFilePreviews classifies pdf and json files by mime type", () => {
   assert.equal(previews.find((p) => p.id === "f2")?.data.type, "pdf");
   assert.equal(previews.find((p) => p.id === "f3")?.data.type, "json");
 });
+
+// Mirrors the real profiler output: a dg:DatabaseConnection whose tables
+// (text/sql FileObjects) reference it via containedIn.
+const DB_PROFILE = {
+  distribution: [
+    { "@type": "dg:DatabaseConnection", "@id": "db1", name: "ds_mathe" },
+    {
+      "@type": "cr:FileObject",
+      "@id": "t1",
+      name: "users",
+      encodingFormat: "text/sql",
+      containedIn: { "@id": "db1" },
+    },
+    {
+      "@type": "cr:FileObject",
+      "@id": "t2",
+      name: "roles",
+      encodingFormat: "text/sql",
+      containedIn: { "@id": "db1" },
+    },
+  ],
+};
+
+test("buildFileTree treats a DatabaseConnection as a folder of its tables", () => {
+  const tree = buildFileTree(DB_PROFILE);
+  assert.equal(tree.length, 1);
+  assert.equal(tree[0].kind, "folder");
+  assert.equal(tree[0].name, "ds_mathe");
+  assert.deepEqual(
+    tree[0].children?.map((child) => child.id),
+    ["t1", "t2"],
+  );
+});
+
+test("buildFilePreviews does not emit a DatabaseConnection container", () => {
+  const ids = buildFilePreviews(DB_PROFILE).map((p) => p.id);
+  assert.ok(!ids.includes("db1"));
+});


### PR DESCRIPTION
Follow-up to #204 (merged) addressing two review caveats.

## 1. Nested file tree
The profile's `distribution` mixes `cr:FileObject` (files) and `cr:FileSet` (folders), with files linking to their folder via `containedIn.@id`. The original parser flattened this.

- New `buildFileTree(profileRaw)` → nested `ProfileTreeNode[]`: FileSets become folders, FileObjects nest under their `containedIn` folder (or sit at the root). `DatasetDetailsPageContent` maps it to nested `DatasetFilesTree` nodes (which already render `children`).
- **Bug fixed along the way:** `buildFilePreviews` now skips `cr:FileSet`, so a folder (e.g. a `pdfs/` FileSet whose `encodingFormat` is `application/pdf`) is no longer surfaced as a fake previewable PDF.

## 2. "Missing values" formula
Changed from the mean of per-column `missingPercentage` to **total missing cells / total cells** = `Σ(missingCount) / (rowCount × columns) × 100`. These are mathematically identical when every column shares a row count (the normal case), so the displayed value is unchanged for well-formed data — this just makes it robust to differing row counts and is the more standard expression. Documented in a code comment.

## Still open (caveat 3)
The first-real-dataset eyeball still needs an authenticated environment. A real `profileRaw` sample will be provided; I'll fold it in as a parser fixture + mapping assertion in a follow-up.

## Verification
- `pnpm test` (Node gate): **102/102** (2 new: nested-tree nesting + FileSet-skip).
- `type-check` + `lint:biome:check`: clean.
- `test:unit`: unchanged vs `develop` baseline; no new failures.