### PR TITLE
DG-200 | Connect dataset recommendations to BE

### DIFF
--- a/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
+++ b/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
@@ -277,7 +277,7 @@ export default function DatasetDetailsPageContent({
             </div>
           </div>
 
-          <DatasetRecommendationsSection />
+          <DatasetRecommendationsSection datasetId={dataset.id} />
         </div>
       </div>
     </div>

--- a/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.test.tsx
+++ b/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.test.tsx
@@ -1,80 +1,78 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import DatasetRecommendationsSection from "./DatasetRecommendationsSection";
 
-const mockPush = vi.fn();
-const mockUseRouter = vi.fn();
-
-vi.mock("next/navigation", () => ({
-  useRouter: () => mockUseRouter(),
+const { getDatasetRecommendations } = vi.hoisted(() => ({
+  getDatasetRecommendations: vi.fn(),
 }));
+const mockPush = vi.fn();
+
+vi.mock("@/hooks/useApi", () => ({
+  useApi: () => ({ getDatasetRecommendations }),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import DatasetRecommendationsSection from "./DatasetRecommendationsSection";
 
 describe("DatasetRecommendationsSection", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockUseRouter.mockReturnValue({
-      push: mockPush,
-      back: vi.fn(),
-      forward: vi.fn(),
-      refresh: vi.fn(),
-      replace: vi.fn(),
-      prefetch: vi.fn(),
-    });
+    getDatasetRecommendations.mockReset();
+    mockPush.mockReset();
   });
 
-  it("renders recommendations from mock data", async () => {
-    render(<DatasetRecommendationsSection />);
+  it("shows the section while loading, then renders the recommended datasets", async () => {
+    let resolve: (value: unknown[]) => void = () => {};
+    getDatasetRecommendations.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
 
-    await waitFor(() => {
-      expect(screen.getByText("You may also like")).toBeInTheDocument();
-    });
+    render(<DatasetRecommendationsSection datasetId="d1" />);
+    expect(screen.getByText("Recommended datasets")).toBeInTheDocument();
 
-    expect(screen.getByText("ERA5 Land")).toBeInTheDocument();
-    expect(screen.getByText("Horizon Europe")).toBeInTheDocument();
-    expect(screen.getByText("Copernicus")).toBeInTheDocument();
-    expect(screen.getByText("EUREKA")).toBeInTheDocument();
-    expect(screen.getByText("Digital Europe")).toBeInTheDocument();
-    expect(
-      screen.getByText("Fifth Space Weather Services"),
-    ).toBeInTheDocument();
+    resolve([
+      {
+        id: "r1",
+        name: "Alpha Dataset",
+        description: "desc",
+        permissions: ["browsedataset"],
+      },
+    ]);
+
+    await waitFor(() =>
+      expect(screen.getByText("Alpha Dataset")).toBeInTheDocument(),
+    );
+    expect(getDatasetRecommendations).toHaveBeenCalledWith("d1");
   });
 
-  it("navigates to dataset details on card click", async () => {
-    render(<DatasetRecommendationsSection />);
+  it("navigates to the dataset details page on card click", async () => {
+    getDatasetRecommendations.mockResolvedValue([
+      { id: "r1", name: "Alpha Dataset", description: "desc" },
+    ]);
+    render(<DatasetRecommendationsSection datasetId="d1" />);
 
-    await waitFor(() => {
-      expect(screen.getByText("ERA5 Land")).toBeInTheDocument();
-    });
-
+    await waitFor(() =>
+      expect(screen.getByText("Alpha Dataset")).toBeInTheDocument(),
+    );
     const card = screen
-      .getByText("ERA5 Land")
+      .getByText("Alpha Dataset")
       .closest("div[role='button']") as HTMLElement | null;
-    if (card) {
-      fireEvent.click(card);
-      await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith(
-          expect.stringContaining(`/datasets/recommendation-1`),
-        );
-      });
-    }
+    if (card) fireEvent.click(card);
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining("/datasets/r1"),
+      ),
+    );
   });
 
-  it("handles keyboard navigation", async () => {
-    render(<DatasetRecommendationsSection />);
-
-    await waitFor(() => {
-      expect(screen.getByText("ERA5 Land")).toBeInTheDocument();
-    });
-
-    const card = screen
-      .getByText("ERA5 Land")
-      .closest("div[role='button']") as HTMLElement | null;
-    if (card) {
-      fireEvent.keyDown(card, { key: "Enter" });
-
-      await waitFor(() => {
-        expect(mockPush).toHaveBeenCalled();
-      });
-    }
+  it("renders nothing when there are no recommendations", async () => {
+    getDatasetRecommendations.mockResolvedValue([]);
+    const { container } = render(
+      <DatasetRecommendationsSection datasetId="d1" />,
+    );
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 });

--- a/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.tsx
@@ -3,111 +3,64 @@
 import { Chip } from "@ui/Chip";
 import FormattedText from "@ui/FormattedText";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { getDisplayCategory } from "@/config/collectionConstants";
 import type { DatasetPlus } from "@/data/dataset";
+import { useApi } from "@/hooks/useApi";
+import { mapApiDatasetToDataset } from "@/lib/datasetMapping";
+import { logError } from "@/lib/logger";
 import { getNavigationUrl } from "@/lib/utils";
 import styles from "./DatasetRecommendationsSection.module.scss";
+import DatasetRecommendationsSkeleton from "./DatasetRecommendationsSkeleton";
 
-const RECOMMENDATIONS_COUNT = 6;
-type MockRecommendation = DatasetPlus & { displayCategory: string };
+interface DatasetRecommendationsSectionProps {
+  datasetId: string;
+}
 
-const mockRecommendations: MockRecommendation[] = [
-  {
-    id: "recommendation-1",
-    title: "ERA5 Land",
-    category: "Weather",
-    displayCategory: "Navigation",
-    access: "Open Access",
-    description:
-      "Galileo provides high-precision satellite navigation services, supporting various applications in transport, agriculture, and emergency response globally since its launch in 2016.",
-    size: "N/A",
-    lastUpdated: "2024-01-01",
-    tags: [],
-    collections: [],
-  },
-  {
-    id: "recommendation-2",
-    title: "Horizon Europe",
-    category: "Weather",
-    displayCategory: "Research",
-    access: "Open Access",
-    description:
-      "Horizon Europe is the EU's key funding program for research and innovation, aiming to enhance scientific excellence and tackle societal challenges, fostering collaboration across disciplines since 2021.",
-    size: "N/A",
-    lastUpdated: "2024-01-01",
-    tags: [],
-    collections: [],
-  },
-  {
-    id: "recommendation-3",
-    title: "Copernicus",
-    category: "Weather",
-    displayCategory: "Weather",
-    access: "Open Access",
-    description:
-      "The Copernicus program offers comprehensive data from its Sentinel satellites, enabling detailed monitoring of land, ocean, and atmosphere. It's crucial for climate change assessment and disaster management since 2014.",
-    size: "N/A",
-    lastUpdated: "2024-01-01",
-    tags: [],
-    collections: [],
-  },
-  {
-    id: "recommendation-4",
-    title: "EUREKA",
-    category: "Weather",
-    displayCategory: "Innovation",
-    access: "Open Access",
-    description:
-      "EUREKA is an intergovernmental network that supports market-oriented R&D, promoting innovation initiatives across Europe since 1985, enhancing competitiveness and economic growth.",
-    size: "N/A",
-    lastUpdated: "2024-01-01",
-    tags: [],
-    collections: [],
-  },
-  {
-    id: "recommendation-5",
-    title: "Digital Europe",
-    category: "Weather",
-    displayCategory: "Technology",
-    access: "Open Access",
-    description:
-      "Digital Europe is a funding program focused on accelerating digital transformation in Europe, aiming to equip the EU with advanced digital skills and infrastructure since 2021.",
-    size: "N/A",
-    lastUpdated: "2024-01-01",
-    tags: [],
-    collections: [],
-  },
-  {
-    id: "recommendation-6",
-    title: "Fifth Space Weather Services",
-    category: "Weather",
-    displayCategory: "Space Monitoring",
-    access: "Open Access",
-    description:
-      "The Fifth Space Weather Services program aims to enhance the prediction and monitoring of space weather phenomena to protect technological infrastructure and improve safety since 2022.",
-    size: "N/A",
-    lastUpdated: "2024-01-01",
-    tags: [],
-    collections: [],
-  },
-];
-
-export default function DatasetRecommendationsSection() {
+export default function DatasetRecommendationsSection({
+  datasetId,
+}: DatasetRecommendationsSectionProps) {
   const router = useRouter();
+  const { getDatasetRecommendations } = useApi();
+  const [recommendations, setRecommendations] = useState<DatasetPlus[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!datasetId) return;
+    let cancelled = false;
+    setIsLoading(true);
+    (async () => {
+      try {
+        const result = await getDatasetRecommendations(datasetId);
+        if (!cancelled) setRecommendations(result.map(mapApiDatasetToDataset));
+      } catch (error) {
+        logError("Failed to load dataset recommendations", error, {
+          datasetId,
+        });
+        if (!cancelled) setRecommendations([]);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, getDatasetRecommendations]);
 
   const handleCardClick = (dataset: DatasetPlus) => {
     router.push(getNavigationUrl(`/datasets/${dataset.id}`));
   };
 
-  const getDisplayCategory = (dataset: MockRecommendation): string =>
-    dataset.displayCategory || dataset.category;
+  if (isLoading) return <DatasetRecommendationsSkeleton />;
+  if (recommendations.length === 0) return null;
 
   return (
     <div className={styles.datasetRecommendationsSection}>
       <h3 className={styles.datasetRecommendationsSection__title}>
-        You may also like
+        Recommended datasets
       </h3>
       <div className={styles.datasetRecommendationsSection__grid}>
-        {mockRecommendations.slice(0, RECOMMENDATIONS_COUNT).map((dataset) => (
+        {recommendations.map((dataset) => (
           <div
             key={dataset.id}
             className={styles.datasetRecommendationsSection__card}
@@ -131,7 +84,7 @@ export default function DatasetRecommendationsSection() {
                   className={styles.datasetRecommendationsSection__cardChips}
                 >
                   <Chip color="info" variant="outline" size="sm">
-                    {getDisplayCategory(dataset)}
+                    {getDisplayCategory(dataset.collections, dataset.category)}
                   </Chip>
                   <Chip
                     color={

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1014,6 +1014,78 @@ export function useApi() {
     [makeRequest],
   );
 
+  const getDatasetRecommendations = useCallback(
+    async (
+      datasetId: string,
+      n = 6,
+      fields: string[] = [
+        "id",
+        "name",
+        "description",
+        "keywords",
+        "fieldOfScience",
+        "license",
+        "url",
+        "mimeType",
+        "datePublished",
+        "collections.id",
+        "collections.name",
+        "collections.code",
+        "permissions",
+      ],
+    ): Promise<any[]> => {
+      if (!token) return [];
+
+      const params = fields.map((f) => `f=${encodeURIComponent(f)}`);
+      params.push(`n=${n}`);
+      const url = `${baseUrl}/gw/api/search/dataset/${encodeURIComponent(
+        datasetId,
+      )}/recommend?${params.join("&")}`;
+
+      logApiRequest("getDatasetRecommendations", { datasetId, n });
+
+      try {
+        // Plain fetch (NOT fetchWithAuth): the recommend endpoint returns
+        // 401 "insufficient rights" for datasets the user can't access, and
+        // fetchWithAuth would treat that as an auth failure and force a logout.
+        // Recommendations are a non-critical footer, so degrade to empty.
+        const response = await fetch(url, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+            oauth2: token,
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            Pragma: "no-cache",
+            Expires: "0",
+            "X-Request-Type": "getDatasetRecommendations",
+          },
+        });
+
+        if (!response.ok) {
+          logApiError(
+            "getDatasetRecommendations",
+            { status: response.status },
+            { datasetId },
+          );
+          return [];
+        }
+
+        const result = await response.json();
+        const items = Array.isArray(result) ? result : [];
+        logApiResponse("getDatasetRecommendations", {
+          datasetId,
+          count: items.length,
+        });
+        return items;
+      } catch (error) {
+        logApiError("getDatasetRecommendations", error, { datasetId });
+        return [];
+      }
+    },
+    [token, baseUrl],
+  );
+
   const getUserFavorites = useCallback(
     async (
       fields: string[] = [
@@ -1593,6 +1665,7 @@ export function useApi() {
     removeDatasetFromUserCollection,
     getDatasetById,
     downloadDatasetFile,
+    getDatasetRecommendations,
     getUserFavorites,
     addFavoriteDataset,
     removeFavoriteDataset,


### PR DESCRIPTION
Closes #200

## Summary
Wires the **"Recommended datasets"** footer on the Dataset Details Page to the recommendation endpoint (it was hardcoded mock). The UI/skeleton already existed; this connects it.

## Endpoint
`GET /api/search/dataset/{datasetId}/recommend?n=6&f=…` → `Dataset[]`. **Verified live** — returns 6 real recommendations for accessible datasets (e.g. EncycNet → Wikipedia Subset / ESCO / Mathematics Learning Assessment). `POST /api/dataset/recommendation-register` exists but is **not** needed from the UI (the GET returns recommendations directly).

## ⚠️ 401 handling (important)
The endpoint returns **`401 "insufficient rights"` per-dataset** for datasets the user can't access. This repo's `fetchWithAuth` treats any 401 as an auth failure and **force-logs-out**. So `getDatasetRecommendations` uses a **plain authed fetch (not `fetchWithAuth`)** and degrades a non-OK response to `[]` — a forbidden recommendation must never log the user out. (In normal use the footer is on a dataset the user can view, so it returns 200.)

## Changes
- **`useApi.getDatasetRecommendations(datasetId, n = 6, fields?)`** — GET recommend, plain authed fetch, returns `Dataset[]` or `[]` on error.
- **`DatasetRecommendationsSection`** — `datasetId` prop; fetch on mount; map via the shared `mapApiDatasetToDataset`; `DatasetRecommendationsSkeleton` while loading; **hide section** on empty/error; title → **"Recommended datasets"**.
- **`DatasetDetailsPageContent`** — passes `datasetId={dataset.id}`.

## Acceptance criteria
- **Label "Recommended datasets"** ✓ · **skeleton loader** ✓ (no layout shift) · standard tile (kept the existing recommendation card).
- **Navigation:** clicking a tile → `/datasets/{id}`; **Back** returns to the originating dataset (router.push history + page re-fetch on `[id]` change).

## Verification
- `pnpm test` (Node gate): **99/99**. type-check + `lint:biome:check`: clean.
- New component tests (loading → loaded → navigate, and empty → hidden): pass; `test:unit` unchanged vs baseline (no new failures).

## Notes for review
- **Card style:** kept the existing custom recommendation card (AC called the tile "already implemented"). Easy swap to the real `DatasetCard` if preferred (Figma node `10704-49362`).
- **Flag-gating:** this footer is not gated by the `datasetRecommendation` feature flag (that gates the chat proposal); out of scope unless wanted.