### PR TITLE
DG-192 | Pinned dataset ID for language and weather pilots

### DIFF
--- a/src/app/chat/ChatPageContent.tsx
+++ b/src/app/chat/ChatPageContent.tsx
@@ -76,6 +76,7 @@ export interface ChatPageContentProps {
   hideCollectionActions?: boolean;
   withLayout?: boolean;
   forcedCollectionId?: string | null;
+  forcedDatasetIds?: string[];
 }
 
 export function ChatPageContent({
@@ -83,8 +84,11 @@ export function ChatPageContent({
   hideCollectionActions,
   withLayout = true,
   forcedCollectionId,
+  forcedDatasetIds,
 }: ChatPageContentProps) {
-  const [selectedDatasets, setSelectedDatasets] = useState<string[]>([]);
+  const [selectedDatasets, setSelectedDatasets] = useState<string[]>(
+    forcedDatasetIds ?? [],
+  );
   const api = useApi();
   const [isMounted, setIsMounted] = useState(false);
   const [chatInitialMessages, setChatInitialMessages] = useState<
@@ -161,7 +165,7 @@ export function ChatPageContent({
             }
           });
         }
-        setSelectedDatasets(datasetIds);
+        setSelectedDatasets(forcedDatasetIds ?? datasetIds);
       };
       fetchHistory();
     } else if (!id && conversationId !== null) {
@@ -171,13 +175,13 @@ export function ChatPageContent({
       isInitializedRef.current = true;
 
       if (isTransitioningFromConversation) {
-        setSelectedDatasets([]);
+        setSelectedDatasets(forcedDatasetIds ?? []);
         sessionStorage.removeItem("lastConversationId");
       }
     } else if (!id && !isInitializedRef.current) {
       isInitializedRef.current = true;
     }
-  }, [isMounted, params, api.hasToken]);
+  }, [isMounted, params, api.hasToken, forcedDatasetIds]);
 
   useEffect(() => {
     const id = params?.conversationId as string | undefined;
@@ -290,7 +294,7 @@ export function ChatPageContent({
       selectedDatasets={selectedDatasets}
       datasets={normalizeDatasets(datasets) as Dataset[]}
       onSelectedDatasetsChange={(datasets) => {
-        setSelectedDatasets(datasets);
+        setSelectedDatasets(forcedDatasetIds ?? datasets);
       }}
       conversationId={conversationId}
       initialMessages={chatInitialMessages ?? undefined}

--- a/src/app/use-case/language/question/page.tsx
+++ b/src/app/use-case/language/question/page.tsx
@@ -6,6 +6,10 @@ import { useState } from "react";
 import DGIcon from "@/components/ui/chat/DGIcon";
 import { useApi } from "@/hooks/useApi";
 
+// Set to a specific dataset ID to restrict analysis to that dataset,
+// or null to use all datasets from the language collection.
+const PINNED_DATASET_ID: string | null = "d84d1a2e-127d-4393-91d0-afb7e4fd9c68";
+
 function Toggle({
   checked,
   onChange,
@@ -73,7 +77,9 @@ export default function LanguageQuestionPage() {
     setIsSubmitting(true);
     setSubmitError(null);
     try {
-      const datasetIds = await fetchLanguageDatasetIds();
+      const datasetIds = PINNED_DATASET_ID
+        ? [PINNED_DATASET_ID]
+        : await fetchLanguageDatasetIds();
       const result = await api.getLinguisticFeatures({
         DatasetIds: datasetIds,
         Query: submittedQuestion,

--- a/src/app/use-case/weather/chat/page.tsx
+++ b/src/app/use-case/weather/chat/page.tsx
@@ -4,6 +4,10 @@ import { Suspense } from "react";
 import { ChatPageContent } from "@/app/chat/ChatPageContent";
 import { useCollections } from "@/contexts/CollectionsContext";
 
+// Set to a specific dataset ID to restrict the chat to that dataset,
+// or null to use all datasets from the meteo collection.
+const PINNED_DATASET_ID: string | null = "3166e649-54c1-4ebf-904e-de9a46cb1b18";
+
 function WeatherChatInner() {
   const { collections } = useCollections();
   const weatherCollection = collections.find(
@@ -14,6 +18,7 @@ function WeatherChatInner() {
     <ChatPageContent
       withLayout={false}
       forcedCollectionId={weatherCollection?.id ?? null}
+      forcedDatasetIds={PINNED_DATASET_ID ? [PINNED_DATASET_ID] : undefined}
       showConversationName={false}
       hideCollectionActions={true}
     />


### PR DESCRIPTION
## Summary
- Added `PINNED_DATASET_ID` constant to language question page and weather chat page — set to a specific dataset ID to restrict analysis/chat to that dataset, or `null` to use all datasets from the collection
- Added `forcedDatasetIds?: string[]` prop to `ChatPageContent` to pre-select and lock specific datasets in the chat
- Fixed 4 paths where `forcedDatasetIds` could be silently overridden:
  - `useState` initializer
  - Loading conversation history from BE (`setSelectedDatasets(forcedDatasetIds ?? datasetIds)`)
  - Transitioning from a previous conversation (`setSelectedDatasets(forcedDatasetIds ?? [])`)
  - Collection selection triggering `onSelectedDatasetsChange` → intercepted in the callback

## Current values
| Pilot | Pinned dataset ID |
|---|---|
| Language | `d84d1a2e-127d-4393-91d0-afb7e4fd9c68` |
| Weather | `3166e649-54c1-4ebf-904e-de9a46cb1b18` |

To use all datasets from the collection, set `PINNED_DATASET_ID = null`.

## Test plan
- [ ] Open weather chat — verify `in-data-explore` payload contains only `3166e649-54c1-4ebf-904e-de9a46cb1b18`
- [ ] Open language question, submit a question and click Start Analysis — verify `linguistic-features` payload contains only `d84d1a2e-127d-4393-91d0-afb7e4fd9c68`
- [ ] Resume an existing weather conversation — verify dataset ID is still pinned, not overridden by conversation history
- [ ] Set `PINNED_DATASET_ID = null` in either pilot — verify all collection datasets are used again
