### PR TITLE
DG-200 | Fix recommendation card grid alignment & text truncation

### DIFF
--- a/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.module.scss
+++ b/src/components/DatasetDetailsPage/DatasetRecommendationsSection/DatasetRecommendationsSection.module.scss
@@ -17,16 +17,18 @@
 
   &__grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    // minmax(0, 1fr) (not 1fr) so non-shrinkable card content can't widen a
+    // track — keeps all columns in a row equal and lets text truncate.
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: $spacing-lg;
     row-gap: 20px;
 
     @media (max-width: $breakpoint-xl - 1px) {
-      grid-template-columns: repeat(2, 1fr);
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     @media (max-width: $breakpoint-md - 1px) {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr);
     }
   }
 
@@ -36,6 +38,7 @@
     background: $color-background;
     padding: 20px;
     cursor: pointer;
+    min-width: 0;
     @include transition-base;
 
     &:hover {
@@ -51,24 +54,27 @@
   &__cardContent {
     @include flex-column;
     gap: $spacing-lg;
+    min-width: 0;
   }
 
   &__cardHeader {
     @include flex-column;
     gap: $spacing-xs;
+    min-width: 0;
   }
 
   &__cardTitle {
     @include font-semibold;
     font-size: $font-size-lg;
     color: $color-primary;
-    line-height: $line-height-tight;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    // block + line-height (not flex centering): text-overflow: ellipsis does
+    // not apply to a flex container's anonymous text item.
     height: 32px;
-    display: flex;
-    align-items: center;
+    line-height: 32px;
+    min-width: 0;
     margin: 0;
   }
 


### PR DESCRIPTION
Follow-up to the reopened #200 (review feedback from @EllaSzafarska): recommendation cards had **inconsistent column widths** and **overflowing text without ellipsis**.

## Root cause
The CSS already declared `repeat(3, 1fr)` + `text-overflow: ellipsis` / `-webkit-line-clamp`, but a **`1fr` grid track has implicit `min-width: auto`** — it won't shrink below its content's min-content size. The card title (`white-space: nowrap`) pushed its column wider than its `1fr` share, so columns came out unequal, and for the same reason the ellipsis/clamp never engaged (the box grew instead of clipping).

## Fix (CSS only)
- Grid tracks → **`minmax(0, 1fr)`** at all three breakpoints (3 / 2 / 1 columns) → equal columns regardless of content.
- **`min-width: 0`** down the `card → cardContent → cardHeader` chain so the existing title ellipsis and description line-clamp actually truncate.
- Title rendered as a **block with `line-height` centering** (was `display: flex`) — `text-overflow: ellipsis` doesn't apply to a flex container's anonymous text item.

## Acceptance criteria (from the comment)
- **Equal grid column alignment** ✓ (`minmax(0,1fr)`)
- **Text truncation with `…`** ✓ (title single-line ellipsis; description 2-line clamp)

## Verification
- Component tests: 3/3 pass (loading → loaded → navigate, empty → hidden). type-check clean.
- CSS-only change; no logic touched.