### PR TITLE
DG-162 | Use GET /api/dataset/{id} + format statistics summary

### DIFF
--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -48,69 +48,48 @@ export default function DatasetDetailsPage() {
       setError(null);
 
       try {
-        const payload = {
-          project: {
-            fields: [
-              "id",
-              "code",
-              "name",
-              "description",
-              "license",
-              "mimeType",
-              "url",
-              "version",
-              "fieldOfScience",
-              "keywords",
-              "size",
-              "datePublished",
-              "lastUpdated",
-              "collections.id",
-              "collections.code",
-              "collections.name",
-              "collections.datasetCount",
-              "permissions.browseDataset",
-              "permissions.editDataset",
-              "permissions.downloadDataset",
-              "permissions.manageDataset",
-              "specification.totalRecords",
-              "specification.timeRange",
-              "specification.geographicCoverage",
-              "specification.populationDensity",
-              "specification.climateZones",
-              "specification.keyBiodiversityAreas",
-              "useCases",
-              "language",
-              "country",
-              "citation",
-              "profileRaw",
-            ],
-          },
-          ids: [datasetId],
-          page: {
-            Offset: 0,
-            Size: 1,
-          },
-          Order: {
-            Items: ["+code"],
-          },
-          Metadata: {
-            CountAll: true,
-          },
-        };
-
-        const response = await api.queryDatasets(payload);
+        const apiDataset = await api.getDatasetById(datasetId, [
+          "id",
+          "code",
+          "name",
+          "description",
+          "license",
+          "mimeType",
+          "url",
+          "version",
+          "fieldOfScience",
+          "keywords",
+          "size",
+          "datePublished",
+          "lastUpdated",
+          "collections.id",
+          "collections.code",
+          "collections.name",
+          "collections.datasetCount",
+          "permissions.browseDataset",
+          "permissions.editDataset",
+          "permissions.downloadDataset",
+          "permissions.manageDataset",
+          "specification.totalRecords",
+          "specification.timeRange",
+          "specification.geographicCoverage",
+          "specification.populationDensity",
+          "specification.climateZones",
+          "specification.keyBiodiversityAreas",
+          "useCases",
+          "language",
+          "country",
+          "citation",
+          "profileRaw",
+        ]);
 
         if (isCancelled) return;
 
-        const items = Array.isArray(response.items) ? response.items : [];
-
-        if (items.length === 0) {
+        if (!apiDataset || typeof apiDataset !== "object") {
           setError("Dataset not found");
           setIsLoading(false);
           return;
         }
-
-        const apiDataset = items[0];
         let mappedDataset = mapApiDatasetToDatasetPlus(apiDataset);
         const hasManageFromDataset = mappedDataset.permissions?.some(
           (p) => p.toLowerCase() === "manage",

--- a/src/components/DatasetDetailsPage/FilePreview/StatisticsTab.tsx
+++ b/src/components/DatasetDetailsPage/FilePreview/StatisticsTab.tsx
@@ -132,7 +132,7 @@ export default function StatisticsTab({
               Total rows
             </span>
             <span className={styles.statisticsTab__summaryValue}>
-              {totalRows}
+              {totalRows.toLocaleString()}
             </span>
           </div>
           <div className={styles.statisticsTab__summaryItem}>
@@ -140,7 +140,7 @@ export default function StatisticsTab({
               Missing values
             </span>
             <span className={styles.statisticsTab__summaryValue}>
-              {totalMissingPercentage}%
+              {Math.round(totalMissingPercentage)}%
             </span>
           </div>
         </div>


### PR DESCRIPTION
Closes the remaining literal-AC gaps on the dataset details preview (#162 substance shipped in #204/#205).

## Changes
- **Endpoint:** the dataset details page now fetches via **`api.getDatasetById` → `GET /api/dataset/{id}`** (with `?f=` projection incl. `profileRaw`), instead of `POST /dataset/query` with an `ids` filter. Matches the endpoint the ticket specifies. (`getDatasetById` already existed in `useApi`, previously unused.)
- **Statistics summary formatting:**
  - **Total rows** → `toLocaleString()` (e.g. `20,357`).
  - **Missing values** → rounded to a whole percent (`Math.round`, e.g. `23%`), matching the design example.

## Intentionally NOT added
- **Stats-panel loading spinner** (listed in the AC): statistics arrive *inside* `profileRaw` — a single dataset fetch already covered by the page loader — so there's no separate analytical call to await. A standalone spinner would have nothing to wait on. Flagging the deliberate omission for the reviewer.

## Verification
- `pnpm test` (Node gate): 99/99. type-check + `lint:biome:check`: clean. `test:unit` unchanged vs baseline.
- Functional equivalence: `GET /{id}` returns the same `Dataset` (incl. `profileRaw`) as the prior query; 404 → existing error path.