### PR TITLE
DG-215 | Build versioned image on git tag push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - develop
+    tags:
+      - "v*.*.*"
 
 env:
   REGISTRY: ghcr.io
@@ -73,6 +75,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=ref,event=tag
 
       - name: Build and push Docker image for dg-app-ui
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83


### PR DESCRIPTION
## What

Make the `Build and Publish Docker Image` workflow produce a version-tagged image when a git tag `vX.Y.Z` is pushed.

- Add `tags: ["v*.*.*"]` to the `push` trigger.
- Add `type=ref,event=tag` to `docker/metadata-action` so the image is tagged with the raw git tag name (e.g. `v0.1.0`, preserving the `v` prefix to match our git tags).

## Why

Today CI only builds `:latest` (main) and `:develop` (develop) — creating a release tag like `v0.1.0` produces **no** image, so deployments cannot pin a specific version. This adds reproducible, version-pinned images for tagged releases.

## Behaviour

| Push | Image tag |
|------|-----------|
| `main` | `:latest` (unchanged) |
| `develop` | `:develop` (unchanged) |
| tag `vX.Y.Z` | `:vX.Y.Z` (new) |

`type=ref,event=tag` only fires on tag pushes, so branch builds are unaffected.

## Notes

- The existing `v0.1.0` tag won't retroactively trigger a build (triggers fire on new tag pushes only).
- GitHub uses the workflow definition from the tagged commit, so this must land in history before future tags will build versioned images.