### PR TITLE
DG-186 | Enable all feature flags by default except customCollection and generalChat

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - develop
+    tags:
+      - "v*.*.*"
 
 env:
   REGISTRY: ghcr.io
@@ -73,6 +75,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=ref,event=tag
 
       - name: Build and push Docker image for dg-app-ui
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -19,8 +19,14 @@ export interface FeatureFlagDefinition {
   defaults: Record<DeploymentEnv, boolean>;
 }
 
-const standardDefaults = (): Record<DeploymentEnv, boolean> => ({
+const enabledEverywhere = (): Record<DeploymentEnv, boolean> => ({
   playground: true,
+  staging: true,
+  production: true,
+});
+
+const disabledEverywhere = (): Record<DeploymentEnv, boolean> => ({
+  playground: false,
   staging: false,
   production: false,
 });
@@ -29,57 +35,57 @@ export const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = [
   {
     id: "datasetRecommendation",
     label: "Dataset recommendation",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "questionRecommendation",
     label: "Question recommendation",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "customCollection",
     label: "Custom collection",
-    defaults: standardDefaults(),
+    defaults: disabledEverywhere(),
   },
   {
     id: "generalChat",
     label: "General chat",
-    defaults: standardDefaults(),
+    defaults: disabledEverywhere(),
   },
   {
     id: "expertMode",
     label: "Expert mode",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "datasetPackage",
     label: "Dataset packaging",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "useCaseWeather",
     label: "Use case – Weather",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "useCaseMath",
     label: "Use case – Math",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "useCaseLifelongLearning",
     label: "Use case – Lifelong learning",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "useCaseLanguage",
     label: "Use case – Language",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "datasetOnboarding",
     label: "Dataset onboarding",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
 ] as const;
 

--- a/tests/featureFlags.test.ts
+++ b/tests/featureFlags.test.ts
@@ -5,10 +5,21 @@ import { normalizeDeploymentEnv } from "../src/lib/featureFlags/environment";
 import { resolveAllFlags, resolveFlag } from "../src/lib/featureFlags/resolve";
 import { parseOverrides } from "../src/lib/featureFlags/storage";
 
-test("resolveFlag returns the environment default when no override is set", () => {
-  assert.equal(resolveFlag("datasetPackage", "playground", {}), true);
-  assert.equal(resolveFlag("datasetPackage", "staging", {}), false);
-  assert.equal(resolveFlag("datasetPackage", "production", {}), false);
+const DISABLED_EVERYWHERE = new Set(["customCollection", "generalChat"]);
+const ENVS = ["playground", "staging", "production"] as const;
+
+test("flags enabled everywhere default to true on every environment", () => {
+  for (const env of ENVS) {
+    assert.equal(resolveFlag("datasetPackage", env, {}), true);
+    assert.equal(resolveFlag("useCaseWeather", env, {}), true);
+  }
+});
+
+test("customCollection and generalChat default to false on every environment", () => {
+  for (const env of ENVS) {
+    assert.equal(resolveFlag("customCollection", env, {}), false);
+    assert.equal(resolveFlag("generalChat", env, {}), false);
+  }
 });
 
 test("resolveFlag lets an override win over the environment default", () => {
@@ -25,7 +36,7 @@ test("resolveFlag lets an override win over the environment default", () => {
 test("resolveFlag ignores a non-boolean override value", () => {
   assert.equal(
     // @ts-expect-error guarding against malformed persisted storage
-    resolveFlag("datasetPackage", "staging", { datasetPackage: "yes" }),
+    resolveFlag("customCollection", "staging", { customCollection: "yes" }),
     false,
   );
 });
@@ -35,12 +46,14 @@ test("resolveFlag returns false for an unknown flag id", () => {
   assert.equal(resolveFlag("doesNotExist", "playground", {}), false);
 });
 
-test("resolveAllFlags resolves every registered flag", () => {
-  const resolved = resolveAllFlags("playground", {});
-  for (const def of FEATURE_FLAGS) {
-    assert.equal(resolved[def.id], true);
+test("resolveAllFlags resolves every registered flag per policy", () => {
+  for (const env of ENVS) {
+    const resolved = resolveAllFlags(env, {});
+    assert.equal(Object.keys(resolved).length, FEATURE_FLAGS.length);
+    for (const def of FEATURE_FLAGS) {
+      assert.equal(resolved[def.id], !DISABLED_EVERYWHERE.has(def.id));
+    }
   }
-  assert.equal(Object.keys(resolved).length, FEATURE_FLAGS.length);
 });
 
 test("normalizeDeploymentEnv accepts the three known targets", () => {


### PR DESCRIPTION
## What
Changes the per-environment **default** for every feature flag so that **all flags are ON by default on every environment (playground, staging, production)** — except **`customCollection`** and **`generalChat`**, which are OFF everywhere.

Replaces the single `standardDefaults()` (playground-only) helper with two intent-named helpers: `enabledEverywhere()` and `disabledEverywhere()`.

## Why
On prod (`DEPLOYMENT_ENV=production`) all flags defaulted to OFF, so the use-case navigation was hidden. The desired policy is for use cases (and the other features) to be visible by default in all environments, with only custom collections and general chat held back.

## Resulting matrix (all environments)
| ON | OFF |
|----|-----|
| datasetRecommendation, questionRecommendation, expertMode, datasetPackage, useCaseWeather, useCaseMath, useCaseLifelongLearning, useCaseLanguage, datasetOnboarding | customCollection, generalChat |

Per-user localStorage overrides (via `/feature-flags`) still win over these defaults.

## Tests
`tests/featureFlags.test.ts` updated to assert the new policy (derives expectations from the exception list so it won't rot as flags are added). Full `pnpm test` green (100 pass), type-check clean.

## Note — reaching prod
This is compiled into the image, so it needs a new release + image rebuild + deployment image bump (not a runtime env change). With this in place, prod can stay `DEPLOYMENT_ENV=production` and still show the use cases.