### PR TITLE
Release v0.1.1 — feature-flag default policy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - develop
+    tags:
+      - "v*.*.*"
 
 env:
   REGISTRY: ghcr.io
@@ -73,6 +75,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=ref,event=tag
 
       - name: Build and push Docker image for dg-app-ui
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gems-frontend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -19,8 +19,14 @@ export interface FeatureFlagDefinition {
   defaults: Record<DeploymentEnv, boolean>;
 }
 
-const standardDefaults = (): Record<DeploymentEnv, boolean> => ({
+const enabledEverywhere = (): Record<DeploymentEnv, boolean> => ({
   playground: true,
+  staging: true,
+  production: true,
+});
+
+const disabledEverywhere = (): Record<DeploymentEnv, boolean> => ({
+  playground: false,
   staging: false,
   production: false,
 });
@@ -29,57 +35,57 @@ export const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = [
   {
     id: "datasetRecommendation",
     label: "Dataset recommendation",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "questionRecommendation",
     label: "Question recommendation",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "customCollection",
     label: "Custom collection",
-    defaults: standardDefaults(),
+    defaults: disabledEverywhere(),
   },
   {
     id: "generalChat",
     label: "General chat",
-    defaults: standardDefaults(),
+    defaults: disabledEverywhere(),
   },
   {
     id: "expertMode",
     label: "Expert mode",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "datasetPackage",
     label: "Dataset packaging",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "useCaseWeather",
     label: "Use case – Weather",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "useCaseMath",
     label: "Use case – Math",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "useCaseLifelongLearning",
     label: "Use case – Lifelong learning",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "useCaseLanguage",
     label: "Use case – Language",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
   {
     id: "datasetOnboarding",
     label: "Dataset onboarding",
-    defaults: standardDefaults(),
+    defaults: enabledEverywhere(),
   },
 ] as const;
 

--- a/tests/featureFlags.test.ts
+++ b/tests/featureFlags.test.ts
@@ -5,10 +5,21 @@ import { normalizeDeploymentEnv } from "../src/lib/featureFlags/environment";
 import { resolveAllFlags, resolveFlag } from "../src/lib/featureFlags/resolve";
 import { parseOverrides } from "../src/lib/featureFlags/storage";
 
-test("resolveFlag returns the environment default when no override is set", () => {
-  assert.equal(resolveFlag("datasetPackage", "playground", {}), true);
-  assert.equal(resolveFlag("datasetPackage", "staging", {}), false);
-  assert.equal(resolveFlag("datasetPackage", "production", {}), false);
+const DISABLED_EVERYWHERE = new Set(["customCollection", "generalChat"]);
+const ENVS = ["playground", "staging", "production"] as const;
+
+test("flags enabled everywhere default to true on every environment", () => {
+  for (const env of ENVS) {
+    assert.equal(resolveFlag("datasetPackage", env, {}), true);
+    assert.equal(resolveFlag("useCaseWeather", env, {}), true);
+  }
+});
+
+test("customCollection and generalChat default to false on every environment", () => {
+  for (const env of ENVS) {
+    assert.equal(resolveFlag("customCollection", env, {}), false);
+    assert.equal(resolveFlag("generalChat", env, {}), false);
+  }
 });
 
 test("resolveFlag lets an override win over the environment default", () => {
@@ -25,7 +36,7 @@ test("resolveFlag lets an override win over the environment default", () => {
 test("resolveFlag ignores a non-boolean override value", () => {
   assert.equal(
     // @ts-expect-error guarding against malformed persisted storage
-    resolveFlag("datasetPackage", "staging", { datasetPackage: "yes" }),
+    resolveFlag("customCollection", "staging", { customCollection: "yes" }),
     false,
   );
 });
@@ -35,12 +46,14 @@ test("resolveFlag returns false for an unknown flag id", () => {
   assert.equal(resolveFlag("doesNotExist", "playground", {}), false);
 });
 
-test("resolveAllFlags resolves every registered flag", () => {
-  const resolved = resolveAllFlags("playground", {});
-  for (const def of FEATURE_FLAGS) {
-    assert.equal(resolved[def.id], true);
+test("resolveAllFlags resolves every registered flag per policy", () => {
+  for (const env of ENVS) {
+    const resolved = resolveAllFlags(env, {});
+    assert.equal(Object.keys(resolved).length, FEATURE_FLAGS.length);
+    for (const def of FEATURE_FLAGS) {
+      assert.equal(resolved[def.id], !DISABLED_EVERYWHERE.has(def.id));
+    }
   }
-  assert.equal(Object.keys(resolved).length, FEATURE_FLAGS.length);
 });
 
 test("normalizeDeploymentEnv accepts the three known targets", () => {


### PR DESCRIPTION
**v0.1.1 release** — brings `develop` into `main` for tagging, same pattern as v0.1.0 (branch off `main` carrying develop's content, so it merges cleanly).

## Changes since v0.1.0
- **Feature-flag default policy (#225):** all flags default ON on every environment (playground/staging/production) **except** `customCollection` and `generalChat` (OFF everywhere). This makes the use-case navigation appear on prod without changing `DEPLOYMENT_ENV`.
- `package.json` version `0.1.0 → 0.1.1`.

`git diff develop` = only the version bump; everything else is develop's content verbatim.

## After merge
1. Tag + publish: `gh release create v0.1.1 --target main --title "v0.1.1" --generate-notes` → builds `ghcr.io/datagems-eosc/dg-app-ui:v0.1.1`.
2. Bump prod (and dev) deployment image to `v0.1.1` → `kubectl apply` → rollout.