### PR TITLE
DG-220 | Bugfix - Feature Flag for general chat

### DIFF
--- a/src/components/ui/SidebarContent.test.tsx
+++ b/src/components/ui/SidebarContent.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FeatureFlagsProvider } from "@/contexts/FeatureFlagsContext";
+import { SidebarContent } from "./SidebarContent";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("./chat/ChatHistoryList", () => ({
+  ChatHistoryList: () => null,
+}));
+
+const defaultProps = {
+  isSidebarOpen: true,
+  isMobile: false,
+  session: null,
+  conversations: [],
+  onMobileSidebarClose: vi.fn(),
+  onDeleteConversation: vi.fn(),
+  onConversationUpdate: vi.fn(),
+  setConversations: vi.fn(),
+};
+
+const renderSidebar = () =>
+  render(
+    <FeatureFlagsProvider>
+      <SidebarContent {...defaultProps} />
+    </FeatureFlagsProvider>,
+  );
+
+describe("SidebarContent – generalChat flag (Hide general chat)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("hides Ask a Question when flag is ON (true)", () => {
+    window.__env = { DEPLOYMENT_ENV: "playground" };
+    renderSidebar();
+    expect(screen.queryByRole("link", { name: /ask a question/i })).toBeNull();
+  });
+
+  it("shows Ask a Question when flag is OFF (false)", () => {
+    window.__env = { DEPLOYMENT_ENV: "staging" };
+    renderSidebar();
+    expect(
+      screen.getByRole("link", { name: /ask a question/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("positions Ask a Question between Browse and Favourites", () => {
+    window.__env = { DEPLOYMENT_ENV: "staging" };
+    renderSidebar();
+
+    const links = screen.getAllByRole("link");
+    const labels = links.map((l) => l.textContent?.trim());
+    const browseIndex = labels.findIndex((l) => l === "Browse");
+    const askIndex = labels.findIndex((l) => /ask a question/i.test(l ?? ""));
+    const favouritesIndex = labels.findIndex((l) => l === "Favourites");
+
+    expect(browseIndex).toBeLessThan(askIndex);
+    expect(askIndex).toBeLessThan(favouritesIndex);
+  });
+});

--- a/src/components/ui/SidebarContent.tsx
+++ b/src/components/ui/SidebarContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 import {
+  Bot,
   Calculator,
   CloudSun,
   FolderSearch,
@@ -60,6 +61,13 @@ const menuItems = [
     icon: Star,
   },
 ];
+
+const askAQuestionItem = {
+  id: "ask-a-question",
+  label: "Ask a Question",
+  href: APP_ROUTES.CHAT,
+  icon: Bot,
+};
 
 const useCaseItems: {
   id: string;
@@ -126,6 +134,9 @@ export function SidebarContent({
 }: SidebarContentProps) {
   const { flags } = useFeatureFlags();
   const visibleUseCaseItems = useCaseItems.filter((item) => flags[item.flag]);
+  const visibleMenuItems = flags.generalChat
+    ? menuItems
+    : [menuItems[0], menuItems[1], askAQuestionItem, menuItems[2]];
 
   return (
     <div
@@ -138,7 +149,7 @@ export function SidebarContent({
             MENU
           </h3>
           <nav className="space-y-2">
-            {menuItems.map((item) => (
+            {visibleMenuItems.map((item) => (
               <MenuItemWithSuspense
                 key={item.id}
                 href={item.href}

--- a/src/components/ui/chat/ChatInput.tsx
+++ b/src/components/ui/chat/ChatInput.tsx
@@ -215,7 +215,7 @@ export const ChatInput = React.forwardRef<ChatInputRef, ChatInputProps>(
                       </span>
                     </div>
                   ) : null}
-                  {generalChatEnabled &&
+                  {!generalChatEnabled &&
                     (collections && onSelectCollection ? (
                       <CollectionsDropdown
                         collections={collections}

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -43,7 +43,7 @@ export const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = [
   },
   {
     id: "generalChat",
-    label: "General chat",
+    label: "Hide general chat",
     defaults: standardDefaults(),
   },
   {


### PR DESCRIPTION
## Summary
- Renamed flag label from "General chat" to "Hide general chat" to reflect inverted/hide semantics
- Connected flag to sidebar: "Ask a question" nav item appears between Browse and Favourites when flag is OFF, hidden when ON
- Aligned Collections button in ChatInput with same inverted flag logic
- Added unit tests for sidebar conditional rendering (3 tests)

## Test plan
- [ ] Navigate to `/feature-flags` — flag row should be labeled "Hide general chat"
- [ ] Set flag to OFF (false) — "Ask a question" link appears in sidebar between Browse and Favourites
- [ ] Set flag to ON (true) — "Ask a question" link disappears from sidebar
- [ ] With flag OFF — go to `/chat`, Collections button is visible
- [ ] With flag ON — go to `/chat`, Collections button is hidden

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)