### PR TITLE
DG-223 | Bind dataset selection buttons to Hide general chat flag

### DIFF
--- a/src/components/Browse/Browse.test.tsx
+++ b/src/components/Browse/Browse.test.tsx
@@ -6,9 +6,18 @@ import Browse from "./Browse";
 const mockUseApi = vi.fn();
 const mockUseCollections = vi.fn();
 const mockUseRouter = vi.fn();
+const mockUseFeatureFlag = vi.fn().mockReturnValue(false);
 
 vi.mock("@/hooks/useApi", () => ({
   useApi: () => mockUseApi(),
+}));
+
+vi.mock("@/contexts/FeatureFlagsContext", () => ({
+  useFeatureFlag: (id: string) => mockUseFeatureFlag(id),
+}));
+
+vi.mock("../DatasetCard", () => ({
+  default: () => null,
 }));
 
 vi.mock("@/contexts/CollectionsContext", () => ({
@@ -37,6 +46,14 @@ describe("Browse - Delete Collection Feature", () => {
     },
   ];
 
+  const baseApiMock = () => ({
+    hasToken: true,
+    getCollectionGrants: vi.fn().mockResolvedValue([]),
+    getFieldsOfScience: vi.fn().mockResolvedValue([]),
+    getLicenses: vi.fn().mockResolvedValue([]),
+    deleteCollection: vi.fn().mockResolvedValue({}),
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -58,7 +75,7 @@ describe("Browse - Delete Collection Feature", () => {
       .mockResolvedValue(["dg_col-delete"]);
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
     });
 
@@ -89,7 +106,7 @@ describe("Browse - Delete Collection Feature", () => {
     const mockGetCollectionGrants = vi.fn().mockResolvedValue([]);
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
     });
 
@@ -122,7 +139,7 @@ describe("Browse - Delete Collection Feature", () => {
       .mockResolvedValue(["dg_col-delete"]);
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
     });
 
@@ -146,7 +163,7 @@ describe("Browse - Delete Collection Feature", () => {
       .mockResolvedValue(["dg_col-delete"]);
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
     });
 
@@ -188,7 +205,7 @@ describe("Browse - Delete Collection Feature", () => {
     const mockPush = vi.fn();
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
       deleteCollection: mockDeleteCollection,
     });
@@ -252,7 +269,7 @@ describe("Browse - Delete Collection Feature", () => {
       .mockRejectedValue(new Error("API Error"));
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
       deleteCollection: mockDeleteCollection,
     });
@@ -288,5 +305,55 @@ describe("Browse - Delete Collection Feature", () => {
         screen.getByText(/Failed to delete collection/i),
       ).toBeInTheDocument();
     });
+  });
+});
+
+describe("Browse – generalChat flag (Hide general chat)", () => {
+  const mockDatasets = [
+    {
+      id: "1",
+      title: "Test Dataset",
+      description: "Test description",
+      license: "MIT",
+      size: "1 MB",
+      datePublished: "2024-01-01",
+      category: "Math" as const,
+      access: "Open Access" as const,
+      lastUpdated: "2024-01-01",
+      tags: ["test"],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseRouter.mockReturnValue({ push: vi.fn() });
+    mockUseCollections.mockReturnValue({
+      apiCollections: [],
+      extraCollections: [],
+      refreshExtraCollections: vi.fn(),
+      notifyCollectionModified: vi.fn(),
+    });
+    mockUseApi.mockReturnValue({
+      hasToken: false,
+      getCollectionGrants: vi.fn().mockResolvedValue([]),
+      getFieldsOfScience: vi.fn().mockResolvedValue([]),
+    });
+  });
+
+  const renderBrowse = () =>
+    render(<Browse datasets={mockDatasets} title="Browse" subtitle="" />);
+
+  it("shows X Selected button when flag is OFF (false)", () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+    renderBrowse();
+    expect(
+      screen.getByRole("button", { name: /selected/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides X Selected button when flag is ON (true)", () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    renderBrowse();
+    expect(screen.queryByRole("button", { name: /selected/i })).toBeNull();
   });
 });

--- a/src/components/Browse/Browse.tsx
+++ b/src/components/Browse/Browse.tsx
@@ -260,6 +260,7 @@ export default function Browse({
   const [isPackageCarouselCollapsed, setIsPackageCarouselCollapsed] =
     useState(false);
   const datasetPackagingEnabled = useFeatureFlag("datasetPackage");
+  const hideGeneralChat = useFeatureFlag("generalChat");
   const isSmartSearchEnabled =
     typeof controlledSmartSearchEnabled === "boolean"
       ? controlledSmartSearchEnabled
@@ -959,17 +960,19 @@ export default function Browse({
                   </Button>
                 ))}
                 {/* Selected datasets counter - clickable when sidebar is closed */}
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    if (showSelectedPanel) handleClosePanel();
-                    else handleOpenPanel();
-                  }}
-                  className="flex items-center gap-2 transition-all duration-200"
-                >
-                  <Database className="w-4 h-4 text-icon" />
-                  {currentSelectedDatasets.length} Selected
-                </Button>
+                {!hideGeneralChat && (
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      if (showSelectedPanel) handleClosePanel();
+                      else handleOpenPanel();
+                    }}
+                    className="flex items-center gap-2 transition-all duration-200"
+                  >
+                    <Database className="w-4 h-4 text-icon" />
+                    {currentSelectedDatasets.length} Selected
+                  </Button>
+                )}
                 {/* Actions dropdown button */}
                 {currentSelectedDatasets.length > 0 && (
                   <div className="relative" data-actions-dropdown>
@@ -1231,7 +1234,7 @@ export default function Browse({
                       onSelect={(isSelected) =>
                         handleDatasetSelect(dataset.id, isSelected)
                       }
-                      showSelectButton={true}
+                      showSelectButton={!hideGeneralChat}
                       isEditMode={isEditMode}
                       onRemove={
                         isEditMode && onRemoveDataset
@@ -1240,7 +1243,7 @@ export default function Browse({
                       }
                       viewMode={viewMode}
                       onAddToCollection={() => handleAddToCollection(dataset)}
-                      showAddButton={showAddButton}
+                      showAddButton={showAddButton && !hideGeneralChat}
                       hasSidePanelOpen={showSelectedPanel && !isPanelClosing}
                       isSmartSearchEnabled={isSmartSearchEnabled}
                     />

--- a/src/components/DatasetDetailsPage/DatasetDetailsPageContent.test.tsx
+++ b/src/components/DatasetDetailsPage/DatasetDetailsPageContent.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseFeatureFlag = vi.fn();
+
+vi.mock("@/contexts/FeatureFlagsContext", () => ({
+  useFeatureFlag: (id: string) => mockUseFeatureFlag(id),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+  usePathname: () => "/datasets/test-id",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  useApi: () => ({ downloadDatasetFile: vi.fn() }),
+}));
+
+vi.mock("./DatasetDescriptionSection/DatasetDescriptionSection", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetFilesTree/DatasetFilesTree", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetHeader/DatasetHeader", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetMetadataBar/DatasetMetadataBar", () => ({
+  default: () => null,
+}));
+vi.mock(
+  "./DatasetRecommendationsSection/DatasetRecommendationsSection",
+  () => ({
+    default: () => null,
+    DatasetRecommendationsSection: () => null,
+  }),
+);
+vi.mock("./DatasetSidebar/DatasetSidebar", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetSpecificationSection/DatasetSpecificationSection", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetTagsSection/DatasetTagsSection", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetUseCasesSection/DatasetUseCasesSection", () => ({
+  default: () => null,
+}));
+vi.mock("./FilePreview/FilePreview", () => ({
+  default: () => null,
+}));
+
+import type { DatasetPlus } from "@/data/dataset";
+import DatasetDetailsPageContent from "./DatasetDetailsPageContent";
+
+const mockDataset: DatasetPlus = {
+  id: "ds-1",
+  title: "Test Dataset",
+  description: "Test",
+  license: "MIT",
+  size: "1 MB",
+  datePublished: "2024-01-01",
+  category: "Math",
+  access: "Open Access",
+  lastUpdated: "2024-01-01",
+  tags: [],
+  permissions: ["Browse"],
+  profileRaw: null,
+} as unknown as DatasetPlus;
+
+describe("DatasetDetailsPageContent – generalChat flag (Hide general chat)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows Select and 0 Selected buttons when flag is OFF (false)", () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+    render(<DatasetDetailsPageContent dataset={mockDataset} />);
+    expect(
+      screen.getByRole("button", { name: /^select$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /selected/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Select and 0 Selected buttons when flag is ON (true)", () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    render(<DatasetDetailsPageContent dataset={mockDataset} />);
+    expect(screen.queryByRole("button", { name: /^select$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /0 selected/i })).toBeNull();
+  });
+
+  it("always shows Edit button regardless of flag", () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    render(<DatasetDetailsPageContent dataset={mockDataset} />);
+    expect(screen.getByRole("button", { name: /^edit$/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
+++ b/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { APP_ROUTES } from "@/config/appUrls";
 import { getDisplayCategory } from "@/config/collectionConstants";
+import { useFeatureFlag } from "@/contexts/FeatureFlagsContext";
 import type { DatasetPlus } from "@/data/dataset";
 import { useApi } from "@/hooks/useApi";
 import {
@@ -69,6 +70,7 @@ export default function DatasetDetailsPageContent({
 }: DatasetDetailsPageContentProps) {
   const router = useRouter();
   const { downloadDatasetFile } = useApi();
+  const hideGeneralChat = useFeatureFlag("generalChat");
 
   const previewEntries = useMemo(
     () => buildFilePreviews(dataset.profileRaw),
@@ -196,12 +198,16 @@ export default function DatasetDetailsPageContent({
                 <Button variant="outline" size="sm">
                   Edit
                 </Button>
-                <Button variant="outline" size="sm">
-                  Select
-                </Button>
-                <Button variant="outline" size="sm">
-                  0 Selected
-                </Button>
+                {!hideGeneralChat && (
+                  <>
+                    <Button variant="outline" size="sm">
+                      Select
+                    </Button>
+                    <Button variant="outline" size="sm">
+                      0 Selected
+                    </Button>
+                  </>
+                )}
               </div>
             </div>
             <DatasetHeader dataset={dataset} />

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.test.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseFeatureFlag = vi.fn();
+
+vi.mock("@/contexts/FeatureFlagsContext", () => ({
+  useFeatureFlag: (id: string) => mockUseFeatureFlag(id),
+}));
+
+import DatasetCollectionSection from "./DatasetCollectionSection";
+
+const defaultProps = {
+  displayCategory: "Math",
+  onAddClick: vi.fn(),
+};
+
+describe("DatasetCollectionSection – generalChat flag (Hide general chat)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows Add button when flag is OFF (false)", () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+    render(<DatasetCollectionSection {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /add/i })).toBeInTheDocument();
+  });
+
+  it("hides Add button when flag is ON (true)", () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    render(<DatasetCollectionSection {...defaultProps} />);
+    expect(screen.queryByRole("button", { name: /add/i })).toBeNull();
+  });
+});

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@ui/Button";
 import { Chip } from "@ui/Chip";
 import { Box, Plus } from "lucide-react";
+import { useFeatureFlag } from "@/contexts/FeatureFlagsContext";
 import styles from "./DatasetSidebarSection.module.scss";
 
 interface DatasetCollectionSectionProps {
@@ -14,6 +15,8 @@ export default function DatasetCollectionSection({
   displayCategory,
   onAddClick,
 }: DatasetCollectionSectionProps) {
+  const hideGeneralChat = useFeatureFlag("generalChat");
+
   return (
     <div className={styles.datasetSidebarSection}>
       <div className={styles.datasetSidebarSection__header}>
@@ -21,15 +24,17 @@ export default function DatasetCollectionSection({
           <Box className={styles.datasetSidebarSection__icon} />
           <h3 className={styles.datasetSidebarSection__title}>Collection</h3>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onAddClick}
-          className={styles.datasetSidebarSection__button}
-        >
-          <Plus className={styles.datasetSidebarSection__buttonIcon} />
-          Add
-        </Button>
+        {!hideGeneralChat && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onAddClick}
+            className={styles.datasetSidebarSection__button}
+          >
+            <Plus className={styles.datasetSidebarSection__buttonIcon} />
+            Add
+          </Button>
+        )}
       </div>
       {displayCategory && (
         <Chip color="grey" variant="regular" size="sm">


### PR DESCRIPTION
## Summary
- Hide **X Selected** counter button in `/browse` when "Hide general chat" flag is ON
- Hide **Select** and **+ Add** inline buttons on dataset cards in `/browse` when flag is ON
- Hide **Select** and **0 Selected** buttons in `/datasets/:id` header when flag is ON (Edit button stays visible)
- Hide **+ Add** button in the DatasetCollectionSection sidebar on `/datasets/:id` when flag is ON
- All changes use the existing `generalChat` flag — no new flag registered
- Added 7 new unit tests across 3 test files; fixed pre-existing Browse test mock gap

## Test plan
- [ ] Navigate to `/feature-flags` and set "Hide general chat" to **ON (true)**
- [ ] Open `/browse` — "X Selected" button, "Select" and "+ Add" on cards are hidden
- [ ] Open `/datasets/:id` — "Select" and "0 Selected" buttons in header are hidden, "Edit" remains visible
- [ ] Open `/datasets/:id` sidebar — "+ Add" next to Collection is hidden
- [ ] Set "Hide general chat" to **OFF (false)** — all above elements reappear

Closes #223