### PR TITLE
DG-221 | Bugfix - Dashboard Browse Datasets button incorrect URL

### DIFF
--- a/src/app/dashboard/DashboardClient.test.tsx
+++ b/src/app/dashboard/DashboardClient.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/contexts/UserContext", () => ({
+  useUser: () => ({ userData: { name: "Test" } }),
+}));
+
+vi.mock("@/contexts/CollectionsContext", () => ({
+  useCollections: () => ({ apiCollections: [] }),
+}));
+
+vi.mock("@/components/DashboardLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/Tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import type React from "react";
+import DashboardClient from "./DashboardClient";
+
+describe("DashboardClient – UseCaseCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Browse Datasets button for Weather links to /use-case/weather/home", () => {
+    render(<DashboardClient />);
+    const links = screen.getAllByRole("link", { name: /browse datasets/i });
+    const weatherLink = links.find((l) =>
+      l.getAttribute("href")?.includes("weather/home"),
+    );
+    expect(weatherLink).toBeDefined();
+  });
+
+  it("Browse Datasets button for Math links to /use-case/math/home", () => {
+    render(<DashboardClient />);
+    const links = screen.getAllByRole("link", { name: /browse datasets/i });
+    const mathLink = links.find((l) =>
+      l.getAttribute("href")?.includes("math/home"),
+    );
+    expect(mathLink).toBeDefined();
+  });
+
+  it("Browse Datasets button for Lifelong Learning links to /use-case/lifelong-learning (no /home)", () => {
+    render(<DashboardClient />);
+    const links = screen.getAllByRole("link", { name: /browse datasets/i });
+    const lifelongLink = links.find((l) => {
+      const href = l.getAttribute("href") ?? "";
+      return href.includes("lifelong-learning") && !href.includes("/home");
+    });
+    expect(lifelongLink).toBeDefined();
+  });
+
+  it("Browse Datasets button for Language links to /use-case/language/home", () => {
+    render(<DashboardClient />);
+    const links = screen.getAllByRole("link", { name: /browse datasets/i });
+    const languageLink = links.find((l) =>
+      l.getAttribute("href")?.includes("language/home"),
+    );
+    expect(languageLink).toBeDefined();
+  });
+
+  it("use-case tile card wrapper is not a link", () => {
+    render(<DashboardClient />);
+    const browseLinks = screen.getAllByRole("link", {
+      name: /browse datasets/i,
+    });
+    expect(browseLinks).toHaveLength(4);
+    for (const link of browseLinks) {
+      expect(link.tagName.toLowerCase()).toBe("a");
+      expect(link.closest("a[href]")).toBe(link);
+    }
+  });
+});

--- a/src/app/dashboard/DashboardClient.tsx
+++ b/src/app/dashboard/DashboardClient.tsx
@@ -14,20 +14,9 @@ import Link from "next/link";
 import type React from "react";
 import DashboardLayout from "@/components/DashboardLayout";
 import { Tooltip } from "@/components/ui/Tooltip";
-import { APP_ROUTES, generateChatUrl } from "@/config/appUrls";
-import { useCollections } from "@/contexts/CollectionsContext";
+import { APP_ROUTES } from "@/config/appUrls";
 import { useUser } from "@/contexts/UserContext";
 import { createUrl } from "@/lib/utils";
-import type { ApiCollection } from "@/types/collection";
-
-function findCollectionByCode(
-  collections: ApiCollection[],
-  codes: string[],
-): ApiCollection | undefined {
-  return collections.find((c) =>
-    codes.some((code) => c.code?.toLowerCase() === code.toLowerCase()),
-  );
-}
 
 interface UseCaseCardProps {
   title: string;
@@ -45,10 +34,7 @@ function UseCaseCard({
   href,
 }: UseCaseCardProps) {
   return (
-    <Link
-      href={href}
-      className="bg-white border border-slate-200 rounded-2xl p-5 flex flex-col justify-between flex-1 min-w-0 hover:shadow-s2 transition-shadow"
-    >
+    <div className="bg-white border border-slate-200 rounded-2xl p-5 flex flex-col justify-between flex-1 min-w-0">
       <div
         className={`${iconBg} rounded-lg p-2 w-11 h-11 flex items-center justify-center mb-4`}
       >
@@ -58,12 +44,15 @@ function UseCaseCard({
         <p className="text-body-16-semibold text-gray-800">{title}</p>
         <p className="text-body-14-regular text-gray-500">{description}</p>
       </div>
-      <div className="border border-slate-300 shadow-s1 rounded-full h-10 flex items-center justify-center">
+      <Link
+        href={href}
+        className="border border-slate-300 shadow-s1 rounded-full h-10 flex items-center justify-center hover:shadow-s2 transition-shadow"
+      >
         <span className="text-body-14-medium text-gray-700">
           Browse Datasets
         </span>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 }
 
@@ -107,24 +96,6 @@ function ComingSoonCard({
 
 export default function DashboardClient() {
   const { userData } = useUser();
-  const { apiCollections } = useCollections();
-
-  const weatherCollection = findCollectionByCode(apiCollections, [
-    "weather",
-    "meteo",
-  ]);
-  const mathCollection = findCollectionByCode(apiCollections, [
-    "math",
-    "mathe",
-  ]);
-  const lifelongCollection = findCollectionByCode(apiCollections, [
-    "lifelong",
-    "learning",
-  ]);
-  const languageCollection = findCollectionByCode(apiCollections, [
-    "language",
-    "languages",
-  ]);
 
   const firstName = userData.name || "there";
 
@@ -134,11 +105,7 @@ export default function DashboardClient() {
       description: "Explore forecasts and weather insights using AI.",
       icon: <CloudSun strokeWidth={1.25} className="w-5 h-5 text-purple-500" />,
       iconBg: "bg-purple-50",
-      href: createUrl(
-        weatherCollection
-          ? generateChatUrl({ collection: weatherCollection.id })
-          : APP_ROUTES.CHAT,
-      ),
+      href: APP_ROUTES.USE_CASES.WEATHER_HOME,
     },
     {
       title: "Ask Math Question",
@@ -147,33 +114,21 @@ export default function DashboardClient() {
         <Calculator strokeWidth={1.25} className="w-5 h-5 text-emerald-600" />
       ),
       iconBg: "bg-emerald-50",
-      href: createUrl(
-        mathCollection
-          ? generateChatUrl({ collection: mathCollection.id })
-          : APP_ROUTES.CHAT,
-      ),
+      href: APP_ROUTES.USE_CASES.MATH_HOME,
     },
     {
       title: "Ask Lifelong Learning Question",
       description: "Expand your skills and knowledge with AI.",
       icon: <BookOpen strokeWidth={1.25} className="w-5 h-5 text-rose-500" />,
       iconBg: "bg-rose-50",
-      href: createUrl(
-        lifelongCollection
-          ? generateChatUrl({ collection: lifelongCollection.id })
-          : APP_ROUTES.CHAT,
-      ),
+      href: APP_ROUTES.USE_CASES.LIFELONG_LEARNING,
     },
     {
       title: "Ask Language Question",
       description: "Language-related questions and AI-power.",
       icon: <Languages strokeWidth={1.25} className="w-5 h-5 text-amber-600" />,
       iconBg: "bg-amber-50",
-      href: createUrl(
-        languageCollection
-          ? generateChatUrl({ collection: languageCollection.id })
-          : APP_ROUTES.CHAT,
-      ),
+      href: APP_ROUTES.USE_CASES.LANGUAGE_HOME,
     },
   ];
 

--- a/src/config/appUrls.ts
+++ b/src/config/appUrls.ts
@@ -39,9 +39,12 @@ export const APP_ROUTES = {
   // Use cases
   USE_CASES: {
     LANGUAGE: "/use-case/language",
+    LANGUAGE_HOME: "/use-case/language/home",
     LIFELONG_LEARNING: "/use-case/lifelong-learning",
     MATH: "/use-case/math",
+    MATH_HOME: "/use-case/math/home",
     WEATHER: "/use-case/weather",
+    WEATHER_HOME: "/use-case/weather/home",
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- Added `WEATHER_HOME`, `MATH_HOME`, `LANGUAGE_HOME` to `APP_ROUTES.USE_CASES` in `appUrls.ts`
- Replaced `<Link>` card wrapper with `<div>` — tile card is no longer globally interactive (no cursor/navigation on card body)
- Scoped navigation exclusively to the **Browse Datasets** button via `<Link>`
- Correct routes per use-case:
  - Weather → `/use-case/weather/home`
  - Math → `/use-case/math/home`
  - Lifelong Learning → `/use-case/lifelong-learning` (no `/home` — exception handled)
  - Language → `/use-case/language/home`
- Removed unused `generateChatUrl`, `useCollections`, `findCollectionByCode`, collection variables from `DashboardClient`
- Added 5 unit tests verifying correct href per use-case and non-interactive card wrapper

## Test plan
- [ ] Navigate to `/dashboard`
- [ ] Click card body (title/icon area) on any use-case tile — no navigation should occur
- [ ] Click **Browse Datasets** on Weather tile → lands on `/use-case/weather/home`
- [ ] Click **Browse Datasets** on Math tile → lands on `/use-case/math/home`
- [ ] Click **Browse Datasets** on Lifelong Learning tile → lands on `/use-case/lifelong-learning`
- [ ] Click **Browse Datasets** on Language tile → lands on `/use-case/language/home`
- [ ] **Browse All Datasets** card and **Explore more features** section are unaffected

Closes #221
