### PR TITLE
DG-209 | Use-case specific dataset overrides via feature flags

### DIFF
--- a/src/app/use-case/language/question/page.tsx
+++ b/src/app/use-case/language/question/page.tsx
@@ -4,11 +4,8 @@ import { ArrowLeft, ArrowRight, ArrowUpRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import DGIcon from "@/components/ui/chat/DGIcon";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
 import { useApi } from "@/hooks/useApi";
-
-// Set to a specific dataset ID to restrict analysis to that dataset,
-// or null to use all datasets from the language collection.
-const PINNED_DATASET_ID: string | null = "d84d1a2e-127d-4393-91d0-afb7e4fd9c68";
 
 function Toggle({
   checked,
@@ -33,6 +30,12 @@ function Toggle({
 export default function LanguageQuestionPage() {
   const router = useRouter();
   const api = useApi();
+  const { flags, datasetIds } = useFeatureFlags();
+
+  const pinnedDatasetId =
+    flags.pinnedDatasetLanguage && datasetIds.pinnedDatasetLanguage
+      ? datasetIds.pinnedDatasetLanguage
+      : null;
   const [question, setQuestion] = useState("");
   const [submittedQuestion, setSubmittedQuestion] = useState("");
   const [phase, setPhase] = useState<"input" | "analysis">("input");
@@ -77,8 +80,8 @@ export default function LanguageQuestionPage() {
     setIsSubmitting(true);
     setSubmitError(null);
     try {
-      const datasetIds = PINNED_DATASET_ID
-        ? [PINNED_DATASET_ID]
+      const datasetIds = pinnedDatasetId
+        ? [pinnedDatasetId]
         : await fetchLanguageDatasetIds();
       const result = await api.getLinguisticFeatures({
         DatasetIds: datasetIds,

--- a/src/app/use-case/weather/chat/page.tsx
+++ b/src/app/use-case/weather/chat/page.tsx
@@ -3,22 +3,28 @@
 import { Suspense } from "react";
 import { ChatPageContent } from "@/app/chat/ChatPageContent";
 import { useCollections } from "@/contexts/CollectionsContext";
-
-// Set to a specific dataset ID to restrict the chat to that dataset,
-// or null to use all datasets from the meteo collection.
-const PINNED_DATASET_ID: string | null = "3166e649-54c1-4ebf-904e-de9a46cb1b18";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
 
 function WeatherChatInner() {
   const { collections } = useCollections();
+  const { flags, datasetIds } = useFeatureFlags();
+
   const weatherCollection = collections.find(
     (c) => c.name?.toLowerCase().trim() === "meteo",
   );
 
+  const pinnedDatasetId =
+    flags.pinnedDatasetWeather && datasetIds.pinnedDatasetWeather
+      ? datasetIds.pinnedDatasetWeather
+      : null;
+
   return (
     <ChatPageContent
       withLayout={false}
-      forcedCollectionId={weatherCollection?.id ?? null}
-      forcedDatasetIds={PINNED_DATASET_ID ? [PINNED_DATASET_ID] : undefined}
+      forcedCollectionId={
+        pinnedDatasetId ? null : (weatherCollection?.id ?? null)
+      }
+      forcedDatasetIds={pinnedDatasetId ? [pinnedDatasetId] : undefined}
       showConversationName={false}
       hideCollectionActions={true}
     />

--- a/src/components/FeatureFlagsManager/FeatureFlagRow.test.tsx
+++ b/src/components/FeatureFlagsManager/FeatureFlagRow.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FeatureFlagRow } from "./FeatureFlagRow";
 
 describe("FeatureFlagRow", () => {
@@ -62,5 +62,104 @@ describe("FeatureFlagRow", () => {
     const toggle = screen.getByRole("button", { name: "Dataset packaging" });
     expect(toggle).toHaveAttribute("aria-pressed", "false");
     expect(toggle).toBeDisabled();
+  });
+
+  it("does not render dataset ID input when onSaveDatasetId is not provided", () => {
+    render(
+      <FeatureFlagRow
+        label="Dataset packaging"
+        value={false}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.queryByLabelText(/dataset id/i)).toBeNull();
+  });
+});
+
+describe("FeatureFlagRow – with dataset ID override", () => {
+  const label = "Use case – Weather - Dataset ID";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders dataset ID input disabled in view mode", () => {
+    render(
+      <FeatureFlagRow
+        label={label}
+        value={false}
+        onSave={vi.fn()}
+        datasetId="abc-123"
+        onSaveDatasetId={vi.fn()}
+      />,
+    );
+    const input = screen.getByLabelText(`Dataset ID for ${label}`);
+    expect(input).toBeInTheDocument();
+    expect(input).toBeDisabled();
+    expect(input).toHaveValue("abc-123");
+  });
+
+  it("enables dataset ID input when editing", async () => {
+    render(
+      <FeatureFlagRow
+        label={label}
+        value={false}
+        onSave={vi.fn()}
+        datasetId="abc-123"
+        onSaveDatasetId={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: `Edit ${label}` }),
+    );
+    expect(screen.getByLabelText(`Dataset ID for ${label}`)).toBeEnabled();
+  });
+
+  it("calls onSaveDatasetId with entered value on save", async () => {
+    const onSaveDatasetId = vi.fn();
+    render(
+      <FeatureFlagRow
+        label={label}
+        value={false}
+        onSave={vi.fn()}
+        datasetId=""
+        onSaveDatasetId={onSaveDatasetId}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: `Edit ${label}` }),
+    );
+    await userEvent.type(
+      screen.getByLabelText(`Dataset ID for ${label}`),
+      "new-id-456",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: `Save ${label}` }),
+    );
+    expect(onSaveDatasetId).toHaveBeenCalledWith("new-id-456");
+  });
+
+  it("resets dataset ID input to original value on cancel", async () => {
+    render(
+      <FeatureFlagRow
+        label={label}
+        value={false}
+        onSave={vi.fn()}
+        datasetId="original-id"
+        onSaveDatasetId={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: `Edit ${label}` }),
+    );
+    const input = screen.getByLabelText(`Dataset ID for ${label}`);
+    await userEvent.clear(input);
+    await userEvent.type(input, "changed-id");
+    await userEvent.click(
+      screen.getByRole("button", { name: `Cancel ${label}` }),
+    );
+    expect(screen.getByLabelText(`Dataset ID for ${label}`)).toHaveValue(
+      "original-id",
+    );
   });
 });

--- a/src/components/FeatureFlagsManager/FeatureFlagRow.tsx
+++ b/src/components/FeatureFlagsManager/FeatureFlagRow.tsx
@@ -8,14 +8,24 @@ interface FeatureFlagRowProps {
   label: string;
   value: boolean;
   onSave: (next: boolean) => void;
+  datasetId?: string | null;
+  onSaveDatasetId?: (value: string) => void;
 }
 
-export function FeatureFlagRow({ label, value, onSave }: FeatureFlagRowProps) {
+export function FeatureFlagRow({
+  label,
+  value,
+  onSave,
+  datasetId,
+  onSaveDatasetId,
+}: FeatureFlagRowProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(value);
+  const [datasetIdDraft, setDatasetIdDraft] = useState(datasetId ?? "");
 
   const startEditing = () => {
     setDraft(value);
+    setDatasetIdDraft(datasetId ?? "");
     setIsEditing(true);
   };
 
@@ -23,53 +33,77 @@ export function FeatureFlagRow({ label, value, onSave }: FeatureFlagRowProps) {
 
   const save = () => {
     onSave(draft);
+    if (onSaveDatasetId) onSaveDatasetId(datasetIdDraft);
     setIsEditing(false);
   };
 
+  const hasDatasetId = onSaveDatasetId !== undefined;
+
   return (
-    <div className="flex items-center gap-4 border-b border-[#e5e9ef] px-5 py-4 last:border-b-0">
-      <span className="flex-1 text-body-16-regular text-gray-750">{label}</span>
+    <div className="flex flex-col border-b border-[#e5e9ef] px-5 py-4 last:border-b-0">
+      <div className="flex items-center gap-4">
+        <span className="flex-1 text-body-16-regular text-gray-750">
+          {label}
+        </span>
 
-      <div className="flex w-[120px] items-center">
-        <SmartSwitch
-          checked={isEditing ? draft : value}
-          onChange={setDraft}
-          disabled={!isEditing}
-          ariaLabel={label}
-        />
-      </div>
+        <div className="flex w-[120px] items-center">
+          <SmartSwitch
+            checked={isEditing ? draft : value}
+            onChange={setDraft}
+            disabled={!isEditing}
+            ariaLabel={label}
+          />
+        </div>
 
-      <div className="flex w-[88px] items-center justify-end gap-2">
-        {isEditing ? (
-          <>
+        <div className="flex w-[88px] items-center justify-end gap-2">
+          {isEditing ? (
+            <>
+              <button
+                type="button"
+                aria-label={`Save ${label}`}
+                onClick={save}
+                className="flex size-8 items-center justify-center rounded-md bg-[#2b7fff] text-white transition-colors hover:bg-[#1d6ff0]"
+              >
+                <Check className="size-4" />
+              </button>
+              <button
+                type="button"
+                aria-label={`Cancel ${label}`}
+                onClick={cancel}
+                className="flex size-8 items-center justify-center rounded-md bg-[#e5e9ef] text-gray-750 transition-colors hover:bg-[#d7dde6]"
+              >
+                <X className="size-4" />
+              </button>
+            </>
+          ) : (
             <button
               type="button"
-              aria-label={`Save ${label}`}
-              onClick={save}
-              className="flex size-8 items-center justify-center rounded-md bg-[#2b7fff] text-white transition-colors hover:bg-[#1d6ff0]"
+              aria-label={`Edit ${label}`}
+              onClick={startEditing}
+              className="flex size-8 items-center justify-center rounded-md border border-[#e5e9ef] bg-white text-gray-750 transition-colors hover:bg-slate-50"
             >
-              <Check className="size-4" />
+              <Pencil className="size-4" />
             </button>
-            <button
-              type="button"
-              aria-label={`Cancel ${label}`}
-              onClick={cancel}
-              className="flex size-8 items-center justify-center rounded-md bg-[#e5e9ef] text-gray-750 transition-colors hover:bg-[#d7dde6]"
-            >
-              <X className="size-4" />
-            </button>
-          </>
-        ) : (
-          <button
-            type="button"
-            aria-label={`Edit ${label}`}
-            onClick={startEditing}
-            className="flex size-8 items-center justify-center rounded-md border border-[#e5e9ef] bg-white text-gray-750 transition-colors hover:bg-slate-50"
-          >
-            <Pencil className="size-4" />
-          </button>
-        )}
+          )}
+        </div>
       </div>
+
+      {hasDatasetId && (
+        <div className="flex items-center gap-3 mt-2">
+          <span className="text-body-14-regular text-[#566b88] shrink-0">
+            Dataset Id:
+          </span>
+          <input
+            type="text"
+            value={isEditing ? datasetIdDraft : (datasetId ?? "")}
+            onChange={(e) => setDatasetIdDraft(e.target.value)}
+            disabled={!isEditing}
+            aria-label={`Dataset ID for ${label}`}
+            placeholder="Enter dataset ID"
+            className="flex-1 rounded-md border border-[#e5e9ef] bg-white px-3 py-1.5 text-body-14-regular text-gray-750 placeholder:text-[#8095ad] outline-none transition-colors disabled:bg-[#f8f9fb] disabled:text-[#8095ad] focus:border-[#2b7fff]"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/FeatureFlagsManager/FeatureFlagsManager.tsx
+++ b/src/components/FeatureFlagsManager/FeatureFlagsManager.tsx
@@ -5,7 +5,8 @@ import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
 import { FeatureFlagRow } from "./FeatureFlagRow";
 
 export function FeatureFlagsManager() {
-  const { flags, setOverride } = useFeatureFlags();
+  const { flags, setOverride, datasetIds, setDatasetOverride } =
+    useFeatureFlags();
 
   return (
     <div className="flex min-h-full justify-center bg-[#f5f7fa] px-4 py-6">
@@ -19,14 +20,22 @@ export function FeatureFlagsManager() {
             <span className="w-[120px]">Current value</span>
             <span className="w-[88px] text-right">Edit</span>
           </div>
-          {FEATURE_FLAGS.map((flag) => (
-            <FeatureFlagRow
-              key={flag.id}
-              label={flag.label}
-              value={flags[flag.id]}
-              onSave={(next) => setOverride(flag.id, next)}
-            />
-          ))}
+          {FEATURE_FLAGS.map((flag) => {
+            const hasDatasetId = flag.defaultDatasetId !== undefined;
+            return (
+              <FeatureFlagRow
+                key={flag.id}
+                label={flag.label}
+                value={flags[flag.id]}
+                onSave={(next) => setOverride(flag.id, next)}
+                {...(hasDatasetId && {
+                  datasetId: datasetIds[flag.id] ?? null,
+                  onSaveDatasetId: (value) =>
+                    setDatasetOverride(flag.id, value),
+                })}
+              />
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -11,12 +11,16 @@ export type FeatureFlagId =
   | "useCaseMath"
   | "useCaseLifelongLearning"
   | "useCaseLanguage"
-  | "datasetOnboarding";
+  | "datasetOnboarding"
+  | "pinnedDatasetWeather"
+  | "pinnedDatasetLanguage"
+  | "pinnedDatasetMath";
 
 export interface FeatureFlagDefinition {
   id: FeatureFlagId;
   label: string;
   defaults: Record<DeploymentEnv, boolean>;
+  defaultDatasetId?: Record<DeploymentEnv, string | null>;
 }
 
 const enabledEverywhere = (): Record<DeploymentEnv, boolean> => ({
@@ -86,6 +90,36 @@ export const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = [
     id: "datasetOnboarding",
     label: "Dataset onboarding",
     defaults: enabledEverywhere(),
+  },
+  {
+    id: "pinnedDatasetWeather",
+    label: "Use case – Weather - Dataset ID",
+    defaults: disabledEverywhere(),
+    defaultDatasetId: {
+      playground: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+      staging: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+      production: "ecd7c0eb-fbfe-4d61-bfed-df8048f648ed",
+    },
+  },
+  {
+    id: "pinnedDatasetLanguage",
+    label: "Use case – Language - Dataset ID",
+    defaults: disabledEverywhere(),
+    defaultDatasetId: {
+      playground: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+      staging: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+      production: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+    },
+  },
+  {
+    id: "pinnedDatasetMath",
+    label: "Use case – Math - Dataset ID",
+    defaults: disabledEverywhere(),
+    defaultDatasetId: {
+      playground: null,
+      staging: null,
+      production: null,
+    },
   },
 ] as const;
 

--- a/src/contexts/FeatureFlagsContext.tsx
+++ b/src/contexts/FeatureFlagsContext.tsx
@@ -10,9 +10,15 @@ import {
   useState,
 } from "react";
 import type { DeploymentEnv, FeatureFlagId } from "@/config/featureFlags";
+import {
+  type DatasetIdOverrides,
+  readDatasetOverrides,
+  writeDatasetOverrides,
+} from "@/lib/featureFlags/datasetOverrides";
 import { getDeploymentEnv } from "@/lib/featureFlags/environment";
 import {
   type FeatureFlagOverrides,
+  resolveAllDatasetIds,
   resolveAllFlags,
 } from "@/lib/featureFlags/resolve";
 import { readOverrides, writeOverrides } from "@/lib/featureFlags/storage";
@@ -23,6 +29,9 @@ interface FeatureFlagsContextValue {
   overrides: FeatureFlagOverrides;
   isHydrated: boolean;
   setOverride: (id: FeatureFlagId, value: boolean) => void;
+  datasetIds: Partial<Record<FeatureFlagId, string | null>>;
+  datasetIdOverrides: DatasetIdOverrides;
+  setDatasetOverride: (id: FeatureFlagId, value: string) => void;
 }
 
 const FeatureFlagsContext = createContext<FeatureFlagsContextValue | undefined>(
@@ -32,10 +41,13 @@ const FeatureFlagsContext = createContext<FeatureFlagsContextValue | undefined>(
 export function FeatureFlagsProvider({ children }: { children: ReactNode }) {
   const environment = useMemo(() => getDeploymentEnv(), []);
   const [overrides, setOverrides] = useState<FeatureFlagOverrides>({});
+  const [datasetIdOverrides, setDatasetIdOverrides] =
+    useState<DatasetIdOverrides>({});
   const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
     setOverrides(readOverrides());
+    setDatasetIdOverrides(readDatasetOverrides());
     setIsHydrated(true);
   }, []);
 
@@ -47,14 +59,50 @@ export function FeatureFlagsProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const setDatasetOverride = useCallback((id: FeatureFlagId, value: string) => {
+    setDatasetIdOverrides((previous) => {
+      const next = { ...previous };
+      if (value.trim()) {
+        next[id] = value.trim();
+      } else {
+        delete next[id];
+      }
+      writeDatasetOverrides(next);
+      return next;
+    });
+  }, []);
+
   const flags = useMemo(
     () => resolveAllFlags(environment, overrides),
     [environment, overrides],
   );
 
+  const datasetIds = useMemo(
+    () => resolveAllDatasetIds(environment, datasetIdOverrides),
+    [environment, datasetIdOverrides],
+  );
+
   const value = useMemo(
-    () => ({ environment, flags, overrides, isHydrated, setOverride }),
-    [environment, flags, overrides, isHydrated, setOverride],
+    () => ({
+      environment,
+      flags,
+      overrides,
+      isHydrated,
+      setOverride,
+      datasetIds,
+      datasetIdOverrides,
+      setDatasetOverride,
+    }),
+    [
+      environment,
+      flags,
+      overrides,
+      isHydrated,
+      setOverride,
+      datasetIds,
+      datasetIdOverrides,
+      setDatasetOverride,
+    ],
   );
 
   return (

--- a/src/lib/featureFlags/datasetOverrides.test.tsx
+++ b/src/lib/featureFlags/datasetOverrides.test.tsx
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DATASET_OVERRIDES_STORAGE_KEY,
+  parseDatasetOverrides,
+  readDatasetOverrides,
+  writeDatasetOverrides,
+} from "./datasetOverrides";
+
+describe("parseDatasetOverrides", () => {
+  it("returns empty object for null", () => {
+    expect(parseDatasetOverrides(null)).toEqual({});
+  });
+
+  it("returns empty object for invalid JSON", () => {
+    expect(parseDatasetOverrides("not json")).toEqual({});
+  });
+
+  it("keeps only known flag IDs with string values", () => {
+    const raw = JSON.stringify({
+      pinnedDatasetWeather: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+      pinnedDatasetLanguage: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+      unknownFlag: "some-id",
+      pinnedDatasetMath: 123,
+    });
+    expect(parseDatasetOverrides(raw)).toEqual({
+      pinnedDatasetWeather: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+      pinnedDatasetLanguage: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+    });
+  });
+});
+
+describe("readDatasetOverrides / writeDatasetOverrides", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns empty object when nothing stored", () => {
+    expect(readDatasetOverrides()).toEqual({});
+  });
+
+  it("round-trips a valid override", () => {
+    writeDatasetOverrides({ pinnedDatasetWeather: "abc-123" });
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(DATASET_OVERRIDES_STORAGE_KEY) ?? "{}",
+      ),
+    ).toMatchObject({ pinnedDatasetWeather: "abc-123" });
+    expect(readDatasetOverrides()).toEqual({ pinnedDatasetWeather: "abc-123" });
+  });
+});

--- a/src/lib/featureFlags/datasetOverrides.ts
+++ b/src/lib/featureFlags/datasetOverrides.ts
@@ -1,0 +1,56 @@
+import { FEATURE_FLAG_IDS, type FeatureFlagId } from "@/config/featureFlags";
+import { isBrowser } from "@/lib/env";
+import { logError } from "@/lib/logger";
+
+export const DATASET_OVERRIDES_STORAGE_KEY = "datagemsDatasetOverrides";
+
+export type DatasetIdOverrides = Partial<Record<FeatureFlagId, string>>;
+
+const KNOWN_IDS = new Set<string>(FEATURE_FLAG_IDS);
+
+export function parseDatasetOverrides(raw: string | null): DatasetIdOverrides {
+  if (!raw) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+
+  const overrides: DatasetIdOverrides = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (KNOWN_IDS.has(key) && typeof value === "string") {
+      overrides[key as FeatureFlagId] = value;
+    }
+  }
+  return overrides;
+}
+
+export function readDatasetOverrides(): DatasetIdOverrides {
+  if (!isBrowser()) return {};
+  try {
+    return parseDatasetOverrides(
+      window.localStorage.getItem(DATASET_OVERRIDES_STORAGE_KEY),
+    );
+  } catch (error) {
+    logError("Failed to read dataset overrides from storage", error);
+    return {};
+  }
+}
+
+export function writeDatasetOverrides(overrides: DatasetIdOverrides): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(
+      DATASET_OVERRIDES_STORAGE_KEY,
+      JSON.stringify(overrides),
+    );
+  } catch (error) {
+    logError("Failed to persist dataset overrides to storage", error);
+  }
+}

--- a/src/lib/featureFlags/resolve.ts
+++ b/src/lib/featureFlags/resolve.ts
@@ -4,6 +4,7 @@ import {
   type FeatureFlagId,
   getFeatureFlagDefinition,
 } from "@/config/featureFlags";
+import type { DatasetIdOverrides } from "@/lib/featureFlags/datasetOverrides";
 
 export type FeatureFlagOverrides = Partial<Record<FeatureFlagId, boolean>>;
 
@@ -25,6 +26,30 @@ export function resolveAllFlags(
   const resolved = {} as Record<FeatureFlagId, boolean>;
   for (const definition of FEATURE_FLAGS) {
     resolved[definition.id] = resolveFlag(definition.id, env, overrides);
+  }
+  return resolved;
+}
+
+export function resolveDatasetId(
+  flagId: FeatureFlagId,
+  env: DeploymentEnv,
+  overrides: DatasetIdOverrides,
+): string | null {
+  const override = overrides[flagId];
+  if (typeof override === "string" && override.trim() !== "") return override;
+  const definition = getFeatureFlagDefinition(flagId);
+  return definition?.defaultDatasetId?.[env] ?? null;
+}
+
+export function resolveAllDatasetIds(
+  env: DeploymentEnv,
+  overrides: DatasetIdOverrides,
+): Partial<Record<FeatureFlagId, string | null>> {
+  const resolved: Partial<Record<FeatureFlagId, string | null>> = {};
+  for (const definition of FEATURE_FLAGS) {
+    if (definition.defaultDatasetId !== undefined) {
+      resolved[definition.id] = resolveDatasetId(definition.id, env, overrides);
+    }
   }
   return resolved;
 }

--- a/tests/featureFlags.test.ts
+++ b/tests/featureFlags.test.ts
@@ -2,10 +2,20 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { FEATURE_FLAGS } from "../src/config/featureFlags";
 import { normalizeDeploymentEnv } from "../src/lib/featureFlags/environment";
-import { resolveAllFlags, resolveFlag } from "../src/lib/featureFlags/resolve";
+import {
+  resolveAllFlags,
+  resolveDatasetId,
+  resolveFlag,
+} from "../src/lib/featureFlags/resolve";
 import { parseOverrides } from "../src/lib/featureFlags/storage";
 
-const DISABLED_EVERYWHERE = new Set(["customCollection", "generalChat"]);
+const DISABLED_EVERYWHERE = new Set([
+  "customCollection",
+  "generalChat",
+  "pinnedDatasetWeather",
+  "pinnedDatasetLanguage",
+  "pinnedDatasetMath",
+]);
 const ENVS = ["playground", "staging", "production"] as const;
 
 test("flags enabled everywhere default to true on every environment", () => {
@@ -76,6 +86,39 @@ test("parseOverrides returns an empty object for null or invalid JSON", () => {
   assert.deepEqual(parseOverrides(null), {});
   assert.deepEqual(parseOverrides("{not json"), {});
   assert.deepEqual(parseOverrides("[1,2,3]"), {});
+});
+
+test("resolveDatasetId returns env default when no override is set", () => {
+  assert.equal(
+    resolveDatasetId("pinnedDatasetWeather", "playground", {}),
+    "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+  );
+  assert.equal(
+    resolveDatasetId("pinnedDatasetWeather", "production", {}),
+    "ecd7c0eb-fbfe-4d61-bfed-df8048f648ed",
+  );
+});
+
+test("resolveDatasetId lets a string override win over the environment default", () => {
+  assert.equal(
+    resolveDatasetId("pinnedDatasetWeather", "playground", {
+      pinnedDatasetWeather: "custom-id",
+    }),
+    "custom-id",
+  );
+});
+
+test("resolveDatasetId returns null for a flag with no defaultDatasetId", () => {
+  assert.equal(resolveDatasetId("datasetPackage", "playground", {}), null);
+});
+
+test("resolveDatasetId falls back to env default when override is empty string", () => {
+  assert.equal(
+    resolveDatasetId("pinnedDatasetWeather", "playground", {
+      pinnedDatasetWeather: "",
+    }),
+    "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+  );
 });
 
 test("parseOverrides keeps only known flag ids with boolean values", () => {


### PR DESCRIPTION
## Summary
Implements a dynamic dataset override mechanism in the Feature Flag admin panel, allowing administrators to pin specific dataset IDs per use-case workspace without code changes.

## Architecture

- **3 new feature flags**: `pinnedDatasetWeather`, `pinnedDatasetLanguage`, `pinnedDatasetMath` — each with env-specific `defaultDatasetId` (playground/staging vs production)
- **New storage layer** (`datasetOverrides.ts`): string dataset ID overrides persisted in localStorage under `datagemsDatasetOverrides`, separate from boolean flag storage
- **Resolution hierarchy**: admin UI override > env default from config > null (no override)
- **Clearing the input** removes the override key → env default restores automatically; empty strings never override

## UI Changes (`/feature-flags`)
- Flags with `defaultDatasetId` render a second row: **"Dataset Id:"** + text input
- Input is disabled in view mode, activates on **Edit**
- Saved alongside the boolean toggle via the same Save button

## Use-Case Behavior
- **Flag OFF**: workspace chat operates normally with full collection scope
- **Flag ON + valid ID**: chat uses exclusively the configured dataset ID; `forcedCollectionId` is set to `null` so any dataset works regardless of which collection it belongs to

## Default Dataset IDs
| Flag | Playground / Staging | Production |
|---|---|---|
| Weather | `3166e649-...` | `ecd7c0eb-...` |
| Language | `d84d1a2e-...` | `d84d1a2e-...` |
| Math | null | null |

## Test plan
- [ ] Navigate to `/feature-flags` — Weather/Language/Math flags show Dataset Id input row
- [ ] Click Edit on Weather flag → input becomes active, enter a dataset ID, save
- [ ] Toggle flag ON → weather chat uses only that dataset ID (regardless of collection)
- [ ] Clear the dataset ID input and save → env default ID restores
- [ ] Toggle flag OFF → chat reverts to full meteo collection scope
- [ ] Language question page: same behavior with `pinnedDatasetLanguage`

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)