### PR TITLE
DG-230 | Fix build failure — unescaped apostrophe in math home page

### DIFF
--- a/src/app/use-case/math/home/page.tsx
+++ b/src/app/use-case/math/home/page.tsx
@@ -99,7 +99,7 @@ export default function MathHomePage() {
                   Practice &amp; Solve
                 </h4>
                 <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
-                  Work through exercises and problems, applying what you've
+                  Work through exercises and problems, applying what you&apos;ve
                   learned.
                 </p>
               </div>


### PR DESCRIPTION
## Summary
Hotfix for CI build failure caused by unescaped apostrophe in JSX.

## Problem
`react/no-unescaped-entities` ESLint error in `src/app/use-case/math/home/page.tsx` line 102 — `you've` contains a raw `'` character which is not allowed in JSX.

## Fix
Replaced `you've` with `you&apos;ve`.

Closes #230