### PR TITLE
Release v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gems-frontend",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/src/app/dashboard/DashboardClient.test.tsx
+++ b/src/app/dashboard/DashboardClient.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/contexts/UserContext", () => ({
+  useUser: () => ({ userData: { name: "Test" } }),
+}));
+
+vi.mock("@/contexts/CollectionsContext", () => ({
+  useCollections: () => ({ apiCollections: [] }),
+}));
+
+vi.mock("@/components/DashboardLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/Tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import type React from "react";
+import DashboardClient from "./DashboardClient";
+
+describe("DashboardClient – UseCaseCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Browse Datasets button for Weather links to /use-case/weather/home", () => {
+    render(<DashboardClient />);
+    const links = screen.getAllByRole("link", { name: /browse datasets/i });
+    const weatherLink = links.find((l) =>
+      l.getAttribute("href")?.includes("weather/home"),
+    );
+    expect(weatherLink).toBeDefined();
+  });
+
+  it("Browse Datasets button for Math links to /use-case/math/home", () => {
+    render(<DashboardClient />);
+    const links = screen.getAllByRole("link", { name: /browse datasets/i });
+    const mathLink = links.find((l) =>
+      l.getAttribute("href")?.includes("math/home"),
+    );
+    expect(mathLink).toBeDefined();
+  });
+
+  it("Browse Datasets button for Lifelong Learning links to /use-case/lifelong-learning (no /home)", () => {
+    render(<DashboardClient />);
+    const links = screen.getAllByRole("link", { name: /browse datasets/i });
+    const lifelongLink = links.find((l) => {
+      const href = l.getAttribute("href") ?? "";
+      return href.includes("lifelong-learning") && !href.includes("/home");
+    });
+    expect(lifelongLink).toBeDefined();
+  });
+
+  it("Browse Datasets button for Language links to /use-case/language/home", () => {
+    render(<DashboardClient />);
+    const links = screen.getAllByRole("link", { name: /browse datasets/i });
+    const languageLink = links.find((l) =>
+      l.getAttribute("href")?.includes("language/home"),
+    );
+    expect(languageLink).toBeDefined();
+  });
+
+  it("renders updated tile titles", () => {
+    render(<DashboardClient />);
+    expect(screen.getByText("Explore Weather Data")).toBeInTheDocument();
+    expect(screen.getByText("Explore MathE Platform")).toBeInTheDocument();
+    expect(screen.getByText("Explore Lifelong Learning")).toBeInTheDocument();
+    expect(screen.getByText("Explore Language Data")).toBeInTheDocument();
+  });
+
+  it("use-case tile card wrapper is not a link", () => {
+    render(<DashboardClient />);
+    const browseLinks = screen.getAllByRole("link", {
+      name: /browse datasets/i,
+    });
+    expect(browseLinks).toHaveLength(4);
+    for (const link of browseLinks) {
+      expect(link.tagName.toLowerCase()).toBe("a");
+      expect(link.closest("a[href]")).toBe(link);
+    }
+  });
+});

--- a/src/app/dashboard/DashboardClient.tsx
+++ b/src/app/dashboard/DashboardClient.tsx
@@ -14,20 +14,9 @@ import Link from "next/link";
 import type React from "react";
 import DashboardLayout from "@/components/DashboardLayout";
 import { Tooltip } from "@/components/ui/Tooltip";
-import { APP_ROUTES, generateChatUrl } from "@/config/appUrls";
-import { useCollections } from "@/contexts/CollectionsContext";
+import { APP_ROUTES } from "@/config/appUrls";
 import { useUser } from "@/contexts/UserContext";
 import { createUrl } from "@/lib/utils";
-import type { ApiCollection } from "@/types/collection";
-
-function findCollectionByCode(
-  collections: ApiCollection[],
-  codes: string[],
-): ApiCollection | undefined {
-  return collections.find((c) =>
-    codes.some((code) => c.code?.toLowerCase() === code.toLowerCase()),
-  );
-}
 
 interface UseCaseCardProps {
   title: string;
@@ -45,25 +34,25 @@ function UseCaseCard({
   href,
 }: UseCaseCardProps) {
   return (
-    <Link
-      href={href}
-      className="bg-white border border-slate-200 rounded-2xl p-5 flex flex-col justify-between flex-1 min-w-0 hover:shadow-s2 transition-shadow"
-    >
+    <div className="bg-white border border-slate-200 rounded-2xl p-5 flex flex-col flex-1 min-w-0">
       <div
         className={`${iconBg} rounded-lg p-2 w-11 h-11 flex items-center justify-center mb-4`}
       >
         {icon}
       </div>
-      <div className="flex flex-col gap-2 mb-5">
+      <div className="flex flex-col gap-2 mb-5 grow">
         <p className="text-body-16-semibold text-gray-800">{title}</p>
         <p className="text-body-14-regular text-gray-500">{description}</p>
       </div>
-      <div className="border border-slate-300 shadow-s1 rounded-full h-10 flex items-center justify-center">
+      <Link
+        href={href}
+        className="border border-slate-300 shadow-s1 rounded-full h-10 flex items-center justify-center hover:shadow-s2 transition-shadow"
+      >
         <span className="text-body-14-medium text-gray-700">
           Browse Datasets
         </span>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 }
 
@@ -107,73 +96,43 @@ function ComingSoonCard({
 
 export default function DashboardClient() {
   const { userData } = useUser();
-  const { apiCollections } = useCollections();
-
-  const weatherCollection = findCollectionByCode(apiCollections, [
-    "weather",
-    "meteo",
-  ]);
-  const mathCollection = findCollectionByCode(apiCollections, [
-    "math",
-    "mathe",
-  ]);
-  const lifelongCollection = findCollectionByCode(apiCollections, [
-    "lifelong",
-    "learning",
-  ]);
-  const languageCollection = findCollectionByCode(apiCollections, [
-    "language",
-    "languages",
-  ]);
 
   const firstName = userData.name || "there";
 
   const useCaseCards: UseCaseCardProps[] = [
     {
-      title: "Ask Weather Question",
-      description: "Explore forecasts and weather insights using AI.",
+      title: "Explore Weather Data",
+      description:
+        "Ask questions in natural language and get answers grounded in real weather datasets.",
       icon: <CloudSun strokeWidth={1.25} className="w-5 h-5 text-purple-500" />,
       iconBg: "bg-purple-50",
-      href: createUrl(
-        weatherCollection
-          ? generateChatUrl({ collection: weatherCollection.id })
-          : APP_ROUTES.CHAT,
-      ),
+      href: APP_ROUTES.USE_CASES.WEATHER_HOME,
     },
     {
-      title: "Ask Math Question",
-      description: "Solve complex math problems with AI.",
+      title: "Explore MathE Platform",
+      description:
+        "Access the MathE platform to discover and work with mathematics datasets.",
       icon: (
         <Calculator strokeWidth={1.25} className="w-5 h-5 text-emerald-600" />
       ),
       iconBg: "bg-emerald-50",
-      href: createUrl(
-        mathCollection
-          ? generateChatUrl({ collection: mathCollection.id })
-          : APP_ROUTES.CHAT,
-      ),
+      href: APP_ROUTES.USE_CASES.MATH_HOME,
     },
     {
-      title: "Ask Lifelong Learning Question",
-      description: "Expand your skills and knowledge with AI.",
+      title: "Explore Lifelong Learning",
+      description:
+        "Identify skill gaps and discover training opportunities for individuals and organizations.",
       icon: <BookOpen strokeWidth={1.25} className="w-5 h-5 text-rose-500" />,
       iconBg: "bg-rose-50",
-      href: createUrl(
-        lifelongCollection
-          ? generateChatUrl({ collection: lifelongCollection.id })
-          : APP_ROUTES.CHAT,
-      ),
+      href: APP_ROUTES.USE_CASES.LIFELONG_LEARNING,
     },
     {
-      title: "Ask Language Question",
-      description: "Language-related questions and AI-power.",
+      title: "Explore Language Data",
+      description:
+        "Research linguistic trends and concepts through natural language questions.",
       icon: <Languages strokeWidth={1.25} className="w-5 h-5 text-amber-600" />,
       iconBg: "bg-amber-50",
-      href: createUrl(
-        languageCollection
-          ? generateChatUrl({ collection: languageCollection.id })
-          : APP_ROUTES.CHAT,
-      ),
+      href: APP_ROUTES.USE_CASES.LANGUAGE_HOME,
     },
   ];
 

--- a/src/app/use-case/language/question/page.tsx
+++ b/src/app/use-case/language/question/page.tsx
@@ -4,11 +4,8 @@ import { ArrowLeft, ArrowRight, ArrowUpRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import DGIcon from "@/components/ui/chat/DGIcon";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
 import { useApi } from "@/hooks/useApi";
-
-// Set to a specific dataset ID to restrict analysis to that dataset,
-// or null to use all datasets from the language collection.
-const PINNED_DATASET_ID: string | null = "d84d1a2e-127d-4393-91d0-afb7e4fd9c68";
 
 function Toggle({
   checked,
@@ -33,6 +30,12 @@ function Toggle({
 export default function LanguageQuestionPage() {
   const router = useRouter();
   const api = useApi();
+  const { flags, datasetIds } = useFeatureFlags();
+
+  const pinnedDatasetId =
+    flags.pinnedDatasetLanguage && datasetIds.pinnedDatasetLanguage
+      ? datasetIds.pinnedDatasetLanguage
+      : null;
   const [question, setQuestion] = useState("");
   const [submittedQuestion, setSubmittedQuestion] = useState("");
   const [phase, setPhase] = useState<"input" | "analysis">("input");
@@ -77,8 +80,8 @@ export default function LanguageQuestionPage() {
     setIsSubmitting(true);
     setSubmitError(null);
     try {
-      const datasetIds = PINNED_DATASET_ID
-        ? [PINNED_DATASET_ID]
+      const datasetIds = pinnedDatasetId
+        ? [pinnedDatasetId]
         : await fetchLanguageDatasetIds();
       const result = await api.getLinguisticFeatures({
         DatasetIds: datasetIds,

--- a/src/app/use-case/math/home/page.test.tsx
+++ b/src/app/use-case/math/home/page.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+import type React from "react";
+import MathHomePage from "./page";
+
+describe("MathHomePage – updated copy", () => {
+  it("renders updated heading and subheading", () => {
+    render(<MathHomePage />);
+    expect(
+      screen.getByRole("heading", { name: "Explore math data on MathE" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Solve complex math problems with AI support"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders updated CTA box title and description", () => {
+    render(<MathHomePage />);
+    expect(
+      screen.getByRole("heading", { name: "Open MathE platform" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Get access to reliable math resources on MathE/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders Go to MathE button with unchanged href", () => {
+    render(<MathHomePage />);
+    const link = screen.getByRole("link", { name: /go to mathe/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/use-case/math/chat");
+  });
+
+  it("renders external platform note below button", () => {
+    render(<MathHomePage />);
+    expect(
+      screen.getByText(
+        "Clicking this button takes you to the external platform.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders updated How it works steps", () => {
+    render(<MathHomePage />);
+    expect(screen.getByText("1. Browse")).toBeInTheDocument();
+    expect(screen.getByText("Browse MathE")).toBeInTheDocument();
+    expect(screen.getByText("2. Learn")).toBeInTheDocument();
+    expect(screen.getByText("Study the Material")).toBeInTheDocument();
+    expect(screen.getByText("3. Solve")).toBeInTheDocument();
+    expect(screen.getByText("Practice & Solve")).toBeInTheDocument();
+  });
+});

--- a/src/app/use-case/math/home/page.tsx
+++ b/src/app/use-case/math/home/page.tsx
@@ -8,10 +8,10 @@ export default function MathHomePage() {
         {/* Hero */}
         <div className="flex flex-col gap-2">
           <h1 className="text-[32px] font-semibold text-[#314158] leading-[1.4]">
-            Explore Math data with AI
+            Explore math data on MathE
           </h1>
           <p className="text-[20px] font-normal text-[#5b708f] leading-[1.4]">
-            Ask questions in natural language get answers from real data
+            Solve complex math problems with AI support
           </p>
         </div>
 
@@ -23,22 +23,26 @@ export default function MathHomePage() {
             </div>
             <div className="flex flex-col gap-2">
               <h2 className="text-[20px] font-semibold text-[#314158] leading-[1.4]">
-                Start Your Research
+                Open MathE platform
               </h2>
               <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
-                Get reliable answers grounded in real math data.
-                <br />
-                Explore patterns, trends, and evidence across trusted datasets.
+                Get access to reliable math resources on MathE. Explore topics,
+                exercises, and evidence across trusted materials.
               </p>
             </div>
           </div>
-          <Link
-            href="/use-case/math/chat"
-            className="inline-flex items-center gap-2 bg-[#052f4a] text-white text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] w-fit shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)]"
-          >
-            Start Research
-            <ArrowRight size={16} />
-          </Link>
+          <div className="flex flex-col gap-2">
+            <Link
+              href="/use-case/math/chat"
+              className="inline-flex items-center gap-2 bg-[#052f4a] text-white text-[14px] font-medium leading-[1.5] px-4 h-10 rounded-[40px] w-fit shadow-[0px_1px_0.5px_rgba(213,218,227,0.3)]"
+            >
+              Go to MathE
+              <ArrowRight size={16} />
+            </Link>
+            <p className="text-[12px] font-normal text-[#5b708f] leading-[1.5]">
+              Clicking this button takes you to the external platform.
+            </p>
+          </div>
         </div>
 
         {/* How it works */}
@@ -51,15 +55,15 @@ export default function MathHomePage() {
             <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
               <div className="bg-[#f5f9ff] inline-flex items-center px-3 h-6 rounded-full w-fit">
                 <span className="text-[12px] font-medium text-[#193cb8] tracking-[0.12px]">
-                  1. Ask
+                  1. Browse
                 </span>
               </div>
               <div className="flex flex-col gap-2">
                 <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
-                  Ask Your Question
+                  Browse MathE
                 </h4>
                 <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
-                  Enter your research question in natural language to start the
+                  Browse mathematics topics and resources to start the
                   exploration.
                 </p>
               </div>
@@ -69,16 +73,16 @@ export default function MathHomePage() {
             <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
               <div className="bg-[#ecfdf5] inline-flex items-center px-3 h-6 rounded-full w-fit">
                 <span className="text-[12px] font-medium text-[#006045] tracking-[0.12px]">
-                  2. Select data
+                  2. Learn
                 </span>
               </div>
               <div className="flex flex-col gap-2">
                 <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
-                  Select Data Sources
+                  Study the Material
                 </h4>
                 <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
-                  Choose relevant datasets that help answer and support your
-                  question.
+                  Access explanations and materials, with hints along the way
+                  and the option to ask questions as you learn.
                 </p>
               </div>
             </div>
@@ -87,16 +91,16 @@ export default function MathHomePage() {
             <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
               <div className="bg-[#fff7ed] inline-flex items-center px-3 h-6 rounded-full w-fit">
                 <span className="text-[12px] font-medium text-[#f54900] tracking-[0.12px]">
-                  3. Explore results
+                  3. Solve
                 </span>
               </div>
               <div className="flex flex-col gap-2">
                 <h4 className="text-[16px] font-semibold text-[#1d293d] leading-[1.5]">
-                  Analyze &amp; Explore
+                  Practice &amp; Solve
                 </h4>
                 <p className="text-[14px] font-normal text-[#5b708f] leading-[1.5]">
-                  Review explanations and insights showing how findings were
-                  generated.
+                  Work through exercises and problems, applying what you&apos;ve
+                  learned.
                 </p>
               </div>
             </div>

--- a/src/app/use-case/weather/chat/page.tsx
+++ b/src/app/use-case/weather/chat/page.tsx
@@ -3,22 +3,28 @@
 import { Suspense } from "react";
 import { ChatPageContent } from "@/app/chat/ChatPageContent";
 import { useCollections } from "@/contexts/CollectionsContext";
-
-// Set to a specific dataset ID to restrict the chat to that dataset,
-// or null to use all datasets from the meteo collection.
-const PINNED_DATASET_ID: string | null = "3166e649-54c1-4ebf-904e-de9a46cb1b18";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
 
 function WeatherChatInner() {
   const { collections } = useCollections();
+  const { flags, datasetIds } = useFeatureFlags();
+
   const weatherCollection = collections.find(
     (c) => c.name?.toLowerCase().trim() === "meteo",
   );
 
+  const pinnedDatasetId =
+    flags.pinnedDatasetWeather && datasetIds.pinnedDatasetWeather
+      ? datasetIds.pinnedDatasetWeather
+      : null;
+
   return (
     <ChatPageContent
       withLayout={false}
-      forcedCollectionId={weatherCollection?.id ?? null}
-      forcedDatasetIds={PINNED_DATASET_ID ? [PINNED_DATASET_ID] : undefined}
+      forcedCollectionId={
+        pinnedDatasetId ? null : (weatherCollection?.id ?? null)
+      }
+      forcedDatasetIds={pinnedDatasetId ? [pinnedDatasetId] : undefined}
       showConversationName={false}
       hideCollectionActions={true}
     />

--- a/src/components/Browse/Browse.test.tsx
+++ b/src/components/Browse/Browse.test.tsx
@@ -6,9 +6,18 @@ import Browse from "./Browse";
 const mockUseApi = vi.fn();
 const mockUseCollections = vi.fn();
 const mockUseRouter = vi.fn();
+const mockUseFeatureFlag = vi.fn().mockReturnValue(false);
 
 vi.mock("@/hooks/useApi", () => ({
   useApi: () => mockUseApi(),
+}));
+
+vi.mock("@/contexts/FeatureFlagsContext", () => ({
+  useFeatureFlag: (id: string) => mockUseFeatureFlag(id),
+}));
+
+vi.mock("../DatasetCard", () => ({
+  default: () => null,
 }));
 
 vi.mock("@/contexts/CollectionsContext", () => ({
@@ -37,6 +46,14 @@ describe("Browse - Delete Collection Feature", () => {
     },
   ];
 
+  const baseApiMock = () => ({
+    hasToken: true,
+    getCollectionGrants: vi.fn().mockResolvedValue([]),
+    getFieldsOfScience: vi.fn().mockResolvedValue([]),
+    getLicenses: vi.fn().mockResolvedValue([]),
+    deleteCollection: vi.fn().mockResolvedValue({}),
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -58,7 +75,7 @@ describe("Browse - Delete Collection Feature", () => {
       .mockResolvedValue(["dg_col-delete"]);
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
     });
 
@@ -89,7 +106,7 @@ describe("Browse - Delete Collection Feature", () => {
     const mockGetCollectionGrants = vi.fn().mockResolvedValue([]);
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
     });
 
@@ -122,7 +139,7 @@ describe("Browse - Delete Collection Feature", () => {
       .mockResolvedValue(["dg_col-delete"]);
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
     });
 
@@ -146,7 +163,7 @@ describe("Browse - Delete Collection Feature", () => {
       .mockResolvedValue(["dg_col-delete"]);
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
     });
 
@@ -188,7 +205,7 @@ describe("Browse - Delete Collection Feature", () => {
     const mockPush = vi.fn();
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
       deleteCollection: mockDeleteCollection,
     });
@@ -252,7 +269,7 @@ describe("Browse - Delete Collection Feature", () => {
       .mockRejectedValue(new Error("API Error"));
 
     mockUseApi.mockReturnValue({
-      hasToken: true,
+      ...baseApiMock(),
       getCollectionGrants: mockGetCollectionGrants,
       deleteCollection: mockDeleteCollection,
     });
@@ -288,5 +305,55 @@ describe("Browse - Delete Collection Feature", () => {
         screen.getByText(/Failed to delete collection/i),
       ).toBeInTheDocument();
     });
+  });
+});
+
+describe("Browse – generalChat flag (Hide general chat)", () => {
+  const mockDatasets = [
+    {
+      id: "1",
+      title: "Test Dataset",
+      description: "Test description",
+      license: "MIT",
+      size: "1 MB",
+      datePublished: "2024-01-01",
+      category: "Math" as const,
+      access: "Open Access" as const,
+      lastUpdated: "2024-01-01",
+      tags: ["test"],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseRouter.mockReturnValue({ push: vi.fn() });
+    mockUseCollections.mockReturnValue({
+      apiCollections: [],
+      extraCollections: [],
+      refreshExtraCollections: vi.fn(),
+      notifyCollectionModified: vi.fn(),
+    });
+    mockUseApi.mockReturnValue({
+      hasToken: false,
+      getCollectionGrants: vi.fn().mockResolvedValue([]),
+      getFieldsOfScience: vi.fn().mockResolvedValue([]),
+    });
+  });
+
+  const renderBrowse = () =>
+    render(<Browse datasets={mockDatasets} title="Browse" subtitle="" />);
+
+  it("shows X Selected button when flag is OFF (false)", () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+    renderBrowse();
+    expect(
+      screen.getByRole("button", { name: /selected/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides X Selected button when flag is ON (true)", () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    renderBrowse();
+    expect(screen.queryByRole("button", { name: /selected/i })).toBeNull();
   });
 });

--- a/src/components/Browse/Browse.tsx
+++ b/src/components/Browse/Browse.tsx
@@ -260,6 +260,7 @@ export default function Browse({
   const [isPackageCarouselCollapsed, setIsPackageCarouselCollapsed] =
     useState(false);
   const datasetPackagingEnabled = useFeatureFlag("datasetPackage");
+  const hideGeneralChat = useFeatureFlag("generalChat");
   const isSmartSearchEnabled =
     typeof controlledSmartSearchEnabled === "boolean"
       ? controlledSmartSearchEnabled
@@ -959,17 +960,19 @@ export default function Browse({
                   </Button>
                 ))}
                 {/* Selected datasets counter - clickable when sidebar is closed */}
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    if (showSelectedPanel) handleClosePanel();
-                    else handleOpenPanel();
-                  }}
-                  className="flex items-center gap-2 transition-all duration-200"
-                >
-                  <Database className="w-4 h-4 text-icon" />
-                  {currentSelectedDatasets.length} Selected
-                </Button>
+                {!hideGeneralChat && (
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      if (showSelectedPanel) handleClosePanel();
+                      else handleOpenPanel();
+                    }}
+                    className="flex items-center gap-2 transition-all duration-200"
+                  >
+                    <Database className="w-4 h-4 text-icon" />
+                    {currentSelectedDatasets.length} Selected
+                  </Button>
+                )}
                 {/* Actions dropdown button */}
                 {currentSelectedDatasets.length > 0 && (
                   <div className="relative" data-actions-dropdown>
@@ -1231,7 +1234,7 @@ export default function Browse({
                       onSelect={(isSelected) =>
                         handleDatasetSelect(dataset.id, isSelected)
                       }
-                      showSelectButton={true}
+                      showSelectButton={!hideGeneralChat}
                       isEditMode={isEditMode}
                       onRemove={
                         isEditMode && onRemoveDataset
@@ -1240,7 +1243,7 @@ export default function Browse({
                       }
                       viewMode={viewMode}
                       onAddToCollection={() => handleAddToCollection(dataset)}
-                      showAddButton={showAddButton}
+                      showAddButton={showAddButton && !hideGeneralChat}
                       hasSidePanelOpen={showSelectedPanel && !isPanelClosing}
                       isSmartSearchEnabled={isSmartSearchEnabled}
                     />

--- a/src/components/DatasetDetailsPage/DatasetDetailsPageContent.test.tsx
+++ b/src/components/DatasetDetailsPage/DatasetDetailsPageContent.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseFeatureFlag = vi.fn();
+
+vi.mock("@/contexts/FeatureFlagsContext", () => ({
+  useFeatureFlag: (id: string) => mockUseFeatureFlag(id),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+  usePathname: () => "/datasets/test-id",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  useApi: () => ({ downloadDatasetFile: vi.fn() }),
+}));
+
+vi.mock("./DatasetDescriptionSection/DatasetDescriptionSection", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetFilesTree/DatasetFilesTree", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetHeader/DatasetHeader", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetMetadataBar/DatasetMetadataBar", () => ({
+  default: () => null,
+}));
+vi.mock(
+  "./DatasetRecommendationsSection/DatasetRecommendationsSection",
+  () => ({
+    default: () => null,
+    DatasetRecommendationsSection: () => null,
+  }),
+);
+vi.mock("./DatasetSidebar/DatasetSidebar", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetSpecificationSection/DatasetSpecificationSection", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetTagsSection/DatasetTagsSection", () => ({
+  default: () => null,
+}));
+vi.mock("./DatasetUseCasesSection/DatasetUseCasesSection", () => ({
+  default: () => null,
+}));
+vi.mock("./FilePreview/FilePreview", () => ({
+  default: () => null,
+}));
+
+import type { DatasetPlus } from "@/data/dataset";
+import DatasetDetailsPageContent from "./DatasetDetailsPageContent";
+
+const mockDataset: DatasetPlus = {
+  id: "ds-1",
+  title: "Test Dataset",
+  description: "Test",
+  license: "MIT",
+  size: "1 MB",
+  datePublished: "2024-01-01",
+  category: "Math",
+  access: "Open Access",
+  lastUpdated: "2024-01-01",
+  tags: [],
+  permissions: ["Browse"],
+  profileRaw: null,
+} as unknown as DatasetPlus;
+
+describe("DatasetDetailsPageContent – generalChat flag (Hide general chat)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows Select and 0 Selected buttons when flag is OFF (false)", () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+    render(<DatasetDetailsPageContent dataset={mockDataset} />);
+    expect(
+      screen.getByRole("button", { name: /^select$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /selected/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Select and 0 Selected buttons when flag is ON (true)", () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    render(<DatasetDetailsPageContent dataset={mockDataset} />);
+    expect(screen.queryByRole("button", { name: /^select$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /0 selected/i })).toBeNull();
+  });
+
+  it("always shows Edit button regardless of flag", () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    render(<DatasetDetailsPageContent dataset={mockDataset} />);
+    expect(screen.getByRole("button", { name: /^edit$/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
+++ b/src/components/DatasetDetailsPage/DatasetDetailsPageContent.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { APP_ROUTES } from "@/config/appUrls";
 import { getDisplayCategory } from "@/config/collectionConstants";
+import { useFeatureFlag } from "@/contexts/FeatureFlagsContext";
 import type { DatasetPlus } from "@/data/dataset";
 import { useApi } from "@/hooks/useApi";
 import {
@@ -69,6 +70,7 @@ export default function DatasetDetailsPageContent({
 }: DatasetDetailsPageContentProps) {
   const router = useRouter();
   const { downloadDatasetFile } = useApi();
+  const hideGeneralChat = useFeatureFlag("generalChat");
 
   const previewEntries = useMemo(
     () => buildFilePreviews(dataset.profileRaw),
@@ -196,12 +198,16 @@ export default function DatasetDetailsPageContent({
                 <Button variant="outline" size="sm">
                   Edit
                 </Button>
-                <Button variant="outline" size="sm">
-                  Select
-                </Button>
-                <Button variant="outline" size="sm">
-                  0 Selected
-                </Button>
+                {!hideGeneralChat && (
+                  <>
+                    <Button variant="outline" size="sm">
+                      Select
+                    </Button>
+                    <Button variant="outline" size="sm">
+                      0 Selected
+                    </Button>
+                  </>
+                )}
               </div>
             </div>
             <DatasetHeader dataset={dataset} />

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.test.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseFeatureFlag = vi.fn();
+
+vi.mock("@/contexts/FeatureFlagsContext", () => ({
+  useFeatureFlag: (id: string) => mockUseFeatureFlag(id),
+}));
+
+import DatasetCollectionSection from "./DatasetCollectionSection";
+
+const defaultProps = {
+  displayCategory: "Math",
+  onAddClick: vi.fn(),
+};
+
+describe("DatasetCollectionSection – generalChat flag (Hide general chat)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows Add button when flag is OFF (false)", () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+    render(<DatasetCollectionSection {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /add/i })).toBeInTheDocument();
+  });
+
+  it("hides Add button when flag is ON (true)", () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    render(<DatasetCollectionSection {...defaultProps} />);
+    expect(screen.queryByRole("button", { name: /add/i })).toBeNull();
+  });
+});

--- a/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSidebar/DatasetCollectionSection.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@ui/Button";
 import { Chip } from "@ui/Chip";
 import { Box, Plus } from "lucide-react";
+import { useFeatureFlag } from "@/contexts/FeatureFlagsContext";
 import styles from "./DatasetSidebarSection.module.scss";
 
 interface DatasetCollectionSectionProps {
@@ -14,6 +15,8 @@ export default function DatasetCollectionSection({
   displayCategory,
   onAddClick,
 }: DatasetCollectionSectionProps) {
+  const hideGeneralChat = useFeatureFlag("generalChat");
+
   return (
     <div className={styles.datasetSidebarSection}>
       <div className={styles.datasetSidebarSection__header}>
@@ -21,15 +24,17 @@ export default function DatasetCollectionSection({
           <Box className={styles.datasetSidebarSection__icon} />
           <h3 className={styles.datasetSidebarSection__title}>Collection</h3>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onAddClick}
-          className={styles.datasetSidebarSection__button}
-        >
-          <Plus className={styles.datasetSidebarSection__buttonIcon} />
-          Add
-        </Button>
+        {!hideGeneralChat && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onAddClick}
+            className={styles.datasetSidebarSection__button}
+          >
+            <Plus className={styles.datasetSidebarSection__buttonIcon} />
+            Add
+          </Button>
+        )}
       </div>
       {displayCategory && (
         <Chip color="grey" variant="regular" size="sm">

--- a/src/components/FeatureFlagsManager/FeatureFlagRow.test.tsx
+++ b/src/components/FeatureFlagsManager/FeatureFlagRow.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FeatureFlagRow } from "./FeatureFlagRow";
 
 describe("FeatureFlagRow", () => {
@@ -62,5 +62,104 @@ describe("FeatureFlagRow", () => {
     const toggle = screen.getByRole("button", { name: "Dataset packaging" });
     expect(toggle).toHaveAttribute("aria-pressed", "false");
     expect(toggle).toBeDisabled();
+  });
+
+  it("does not render dataset ID input when onSaveDatasetId is not provided", () => {
+    render(
+      <FeatureFlagRow
+        label="Dataset packaging"
+        value={false}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.queryByLabelText(/dataset id/i)).toBeNull();
+  });
+});
+
+describe("FeatureFlagRow – with dataset ID override", () => {
+  const label = "Use case – Weather - Dataset ID";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders dataset ID input disabled in view mode", () => {
+    render(
+      <FeatureFlagRow
+        label={label}
+        value={false}
+        onSave={vi.fn()}
+        datasetId="abc-123"
+        onSaveDatasetId={vi.fn()}
+      />,
+    );
+    const input = screen.getByLabelText(`Dataset ID for ${label}`);
+    expect(input).toBeInTheDocument();
+    expect(input).toBeDisabled();
+    expect(input).toHaveValue("abc-123");
+  });
+
+  it("enables dataset ID input when editing", async () => {
+    render(
+      <FeatureFlagRow
+        label={label}
+        value={false}
+        onSave={vi.fn()}
+        datasetId="abc-123"
+        onSaveDatasetId={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: `Edit ${label}` }),
+    );
+    expect(screen.getByLabelText(`Dataset ID for ${label}`)).toBeEnabled();
+  });
+
+  it("calls onSaveDatasetId with entered value on save", async () => {
+    const onSaveDatasetId = vi.fn();
+    render(
+      <FeatureFlagRow
+        label={label}
+        value={false}
+        onSave={vi.fn()}
+        datasetId=""
+        onSaveDatasetId={onSaveDatasetId}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: `Edit ${label}` }),
+    );
+    await userEvent.type(
+      screen.getByLabelText(`Dataset ID for ${label}`),
+      "new-id-456",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: `Save ${label}` }),
+    );
+    expect(onSaveDatasetId).toHaveBeenCalledWith("new-id-456");
+  });
+
+  it("resets dataset ID input to original value on cancel", async () => {
+    render(
+      <FeatureFlagRow
+        label={label}
+        value={false}
+        onSave={vi.fn()}
+        datasetId="original-id"
+        onSaveDatasetId={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: `Edit ${label}` }),
+    );
+    const input = screen.getByLabelText(`Dataset ID for ${label}`);
+    await userEvent.clear(input);
+    await userEvent.type(input, "changed-id");
+    await userEvent.click(
+      screen.getByRole("button", { name: `Cancel ${label}` }),
+    );
+    expect(screen.getByLabelText(`Dataset ID for ${label}`)).toHaveValue(
+      "original-id",
+    );
   });
 });

--- a/src/components/FeatureFlagsManager/FeatureFlagRow.tsx
+++ b/src/components/FeatureFlagsManager/FeatureFlagRow.tsx
@@ -8,14 +8,24 @@ interface FeatureFlagRowProps {
   label: string;
   value: boolean;
   onSave: (next: boolean) => void;
+  datasetId?: string | null;
+  onSaveDatasetId?: (value: string) => void;
 }
 
-export function FeatureFlagRow({ label, value, onSave }: FeatureFlagRowProps) {
+export function FeatureFlagRow({
+  label,
+  value,
+  onSave,
+  datasetId,
+  onSaveDatasetId,
+}: FeatureFlagRowProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(value);
+  const [datasetIdDraft, setDatasetIdDraft] = useState(datasetId ?? "");
 
   const startEditing = () => {
     setDraft(value);
+    setDatasetIdDraft(datasetId ?? "");
     setIsEditing(true);
   };
 
@@ -23,53 +33,77 @@ export function FeatureFlagRow({ label, value, onSave }: FeatureFlagRowProps) {
 
   const save = () => {
     onSave(draft);
+    if (onSaveDatasetId) onSaveDatasetId(datasetIdDraft);
     setIsEditing(false);
   };
 
+  const hasDatasetId = onSaveDatasetId !== undefined;
+
   return (
-    <div className="flex items-center gap-4 border-b border-[#e5e9ef] px-5 py-4 last:border-b-0">
-      <span className="flex-1 text-body-16-regular text-gray-750">{label}</span>
+    <div className="flex flex-col border-b border-[#e5e9ef] px-5 py-4 last:border-b-0">
+      <div className="flex items-center gap-4">
+        <span className="flex-1 text-body-16-regular text-gray-750">
+          {label}
+        </span>
 
-      <div className="flex w-[120px] items-center">
-        <SmartSwitch
-          checked={isEditing ? draft : value}
-          onChange={setDraft}
-          disabled={!isEditing}
-          ariaLabel={label}
-        />
-      </div>
+        <div className="flex w-[120px] items-center">
+          <SmartSwitch
+            checked={isEditing ? draft : value}
+            onChange={setDraft}
+            disabled={!isEditing}
+            ariaLabel={label}
+          />
+        </div>
 
-      <div className="flex w-[88px] items-center justify-end gap-2">
-        {isEditing ? (
-          <>
+        <div className="flex w-[88px] items-center justify-end gap-2">
+          {isEditing ? (
+            <>
+              <button
+                type="button"
+                aria-label={`Save ${label}`}
+                onClick={save}
+                className="flex size-8 items-center justify-center rounded-md bg-[#2b7fff] text-white transition-colors hover:bg-[#1d6ff0]"
+              >
+                <Check className="size-4" />
+              </button>
+              <button
+                type="button"
+                aria-label={`Cancel ${label}`}
+                onClick={cancel}
+                className="flex size-8 items-center justify-center rounded-md bg-[#e5e9ef] text-gray-750 transition-colors hover:bg-[#d7dde6]"
+              >
+                <X className="size-4" />
+              </button>
+            </>
+          ) : (
             <button
               type="button"
-              aria-label={`Save ${label}`}
-              onClick={save}
-              className="flex size-8 items-center justify-center rounded-md bg-[#2b7fff] text-white transition-colors hover:bg-[#1d6ff0]"
+              aria-label={`Edit ${label}`}
+              onClick={startEditing}
+              className="flex size-8 items-center justify-center rounded-md border border-[#e5e9ef] bg-white text-gray-750 transition-colors hover:bg-slate-50"
             >
-              <Check className="size-4" />
+              <Pencil className="size-4" />
             </button>
-            <button
-              type="button"
-              aria-label={`Cancel ${label}`}
-              onClick={cancel}
-              className="flex size-8 items-center justify-center rounded-md bg-[#e5e9ef] text-gray-750 transition-colors hover:bg-[#d7dde6]"
-            >
-              <X className="size-4" />
-            </button>
-          </>
-        ) : (
-          <button
-            type="button"
-            aria-label={`Edit ${label}`}
-            onClick={startEditing}
-            className="flex size-8 items-center justify-center rounded-md border border-[#e5e9ef] bg-white text-gray-750 transition-colors hover:bg-slate-50"
-          >
-            <Pencil className="size-4" />
-          </button>
-        )}
+          )}
+        </div>
       </div>
+
+      {hasDatasetId && (
+        <div className="flex items-center gap-3 mt-2">
+          <span className="text-body-14-regular text-[#566b88] shrink-0">
+            Dataset Id:
+          </span>
+          <input
+            type="text"
+            value={isEditing ? datasetIdDraft : (datasetId ?? "")}
+            onChange={(e) => setDatasetIdDraft(e.target.value)}
+            disabled={!isEditing}
+            aria-label={`Dataset ID for ${label}`}
+            placeholder="Enter dataset ID"
+            className="flex-1 rounded-md border border-[#e5e9ef] bg-white px-3 py-1.5 text-body-14-regular text-gray-750 placeholder:text-[#8095ad] outline-none transition-colors disabled:bg-[#f8f9fb] disabled:text-[#8095ad] focus:border-[#2b7fff]"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/FeatureFlagsManager/FeatureFlagsManager.tsx
+++ b/src/components/FeatureFlagsManager/FeatureFlagsManager.tsx
@@ -5,7 +5,8 @@ import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
 import { FeatureFlagRow } from "./FeatureFlagRow";
 
 export function FeatureFlagsManager() {
-  const { flags, setOverride } = useFeatureFlags();
+  const { flags, setOverride, datasetIds, setDatasetOverride } =
+    useFeatureFlags();
 
   return (
     <div className="flex min-h-full justify-center bg-[#f5f7fa] px-4 py-6">
@@ -19,14 +20,22 @@ export function FeatureFlagsManager() {
             <span className="w-[120px]">Current value</span>
             <span className="w-[88px] text-right">Edit</span>
           </div>
-          {FEATURE_FLAGS.map((flag) => (
-            <FeatureFlagRow
-              key={flag.id}
-              label={flag.label}
-              value={flags[flag.id]}
-              onSave={(next) => setOverride(flag.id, next)}
-            />
-          ))}
+          {FEATURE_FLAGS.map((flag) => {
+            const hasDatasetId = flag.defaultDatasetId !== undefined;
+            return (
+              <FeatureFlagRow
+                key={flag.id}
+                label={flag.label}
+                value={flags[flag.id]}
+                onSave={(next) => setOverride(flag.id, next)}
+                {...(hasDatasetId && {
+                  datasetId: datasetIds[flag.id] ?? null,
+                  onSaveDatasetId: (value) =>
+                    setDatasetOverride(flag.id, value),
+                })}
+              />
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/components/ui/SidebarContent.test.tsx
+++ b/src/components/ui/SidebarContent.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FeatureFlagsProvider } from "@/contexts/FeatureFlagsContext";
+import { SidebarContent } from "./SidebarContent";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("./chat/ChatHistoryList", () => ({
+  ChatHistoryList: () => null,
+}));
+
+const defaultProps = {
+  isSidebarOpen: true,
+  isMobile: false,
+  session: null,
+  conversations: [],
+  onMobileSidebarClose: vi.fn(),
+  onDeleteConversation: vi.fn(),
+  onConversationUpdate: vi.fn(),
+  setConversations: vi.fn(),
+};
+
+const renderSidebar = () =>
+  render(
+    <FeatureFlagsProvider>
+      <SidebarContent {...defaultProps} />
+    </FeatureFlagsProvider>,
+  );
+
+describe("SidebarContent – generalChat flag (Hide general chat)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("hides Ask a Question when flag is ON (true)", () => {
+    window.__env = { DEPLOYMENT_ENV: "playground" };
+    renderSidebar();
+    expect(screen.queryByRole("link", { name: /ask a question/i })).toBeNull();
+  });
+
+  it("shows Ask a Question when flag is OFF (false)", () => {
+    window.__env = { DEPLOYMENT_ENV: "staging" };
+    renderSidebar();
+    expect(
+      screen.getByRole("link", { name: /ask a question/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("positions Ask a Question between Browse and Favourites", () => {
+    window.__env = { DEPLOYMENT_ENV: "staging" };
+    renderSidebar();
+
+    const links = screen.getAllByRole("link");
+    const labels = links.map((l) => l.textContent?.trim());
+    const browseIndex = labels.findIndex((l) => l === "Browse");
+    const askIndex = labels.findIndex((l) => /ask a question/i.test(l ?? ""));
+    const favouritesIndex = labels.findIndex((l) => l === "Favourites");
+
+    expect(browseIndex).toBeLessThan(askIndex);
+    expect(askIndex).toBeLessThan(favouritesIndex);
+  });
+});

--- a/src/components/ui/SidebarContent.tsx
+++ b/src/components/ui/SidebarContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 import {
+  Bot,
   Calculator,
   CloudSun,
   FolderSearch,
@@ -60,6 +61,13 @@ const menuItems = [
     icon: Star,
   },
 ];
+
+const askAQuestionItem = {
+  id: "ask-a-question",
+  label: "Ask a Question",
+  href: APP_ROUTES.CHAT,
+  icon: Bot,
+};
 
 const useCaseItems: {
   id: string;
@@ -126,6 +134,9 @@ export function SidebarContent({
 }: SidebarContentProps) {
   const { flags } = useFeatureFlags();
   const visibleUseCaseItems = useCaseItems.filter((item) => flags[item.flag]);
+  const visibleMenuItems = flags.generalChat
+    ? menuItems
+    : [menuItems[0], menuItems[1], askAQuestionItem, menuItems[2]];
 
   return (
     <div
@@ -138,7 +149,7 @@ export function SidebarContent({
             MENU
           </h3>
           <nav className="space-y-2">
-            {menuItems.map((item) => (
+            {visibleMenuItems.map((item) => (
               <MenuItemWithSuspense
                 key={item.id}
                 href={item.href}

--- a/src/components/ui/chat/ChatInput.tsx
+++ b/src/components/ui/chat/ChatInput.tsx
@@ -215,7 +215,7 @@ export const ChatInput = React.forwardRef<ChatInputRef, ChatInputProps>(
                       </span>
                     </div>
                   ) : null}
-                  {generalChatEnabled &&
+                  {!generalChatEnabled &&
                     (collections && onSelectCollection ? (
                       <CollectionsDropdown
                         collections={collections}

--- a/src/config/appUrls.ts
+++ b/src/config/appUrls.ts
@@ -39,9 +39,12 @@ export const APP_ROUTES = {
   // Use cases
   USE_CASES: {
     LANGUAGE: "/use-case/language",
+    LANGUAGE_HOME: "/use-case/language/home",
     LIFELONG_LEARNING: "/use-case/lifelong-learning",
     MATH: "/use-case/math",
+    MATH_HOME: "/use-case/math/home",
     WEATHER: "/use-case/weather",
+    WEATHER_HOME: "/use-case/weather/home",
   },
 } as const;
 

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -11,12 +11,16 @@ export type FeatureFlagId =
   | "useCaseMath"
   | "useCaseLifelongLearning"
   | "useCaseLanguage"
-  | "datasetOnboarding";
+  | "datasetOnboarding"
+  | "pinnedDatasetWeather"
+  | "pinnedDatasetLanguage"
+  | "pinnedDatasetMath";
 
 export interface FeatureFlagDefinition {
   id: FeatureFlagId;
   label: string;
   defaults: Record<DeploymentEnv, boolean>;
+  defaultDatasetId?: Record<DeploymentEnv, string | null>;
 }
 
 const enabledEverywhere = (): Record<DeploymentEnv, boolean> => ({
@@ -49,7 +53,7 @@ export const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = [
   },
   {
     id: "generalChat",
-    label: "General chat",
+    label: "Hide general chat",
     defaults: disabledEverywhere(),
   },
   {
@@ -86,6 +90,36 @@ export const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = [
     id: "datasetOnboarding",
     label: "Dataset onboarding",
     defaults: enabledEverywhere(),
+  },
+  {
+    id: "pinnedDatasetWeather",
+    label: "Use case – Weather - Dataset ID",
+    defaults: disabledEverywhere(),
+    defaultDatasetId: {
+      playground: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+      staging: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+      production: "ecd7c0eb-fbfe-4d61-bfed-df8048f648ed",
+    },
+  },
+  {
+    id: "pinnedDatasetLanguage",
+    label: "Use case – Language - Dataset ID",
+    defaults: disabledEverywhere(),
+    defaultDatasetId: {
+      playground: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+      staging: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+      production: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+    },
+  },
+  {
+    id: "pinnedDatasetMath",
+    label: "Use case – Math - Dataset ID",
+    defaults: disabledEverywhere(),
+    defaultDatasetId: {
+      playground: null,
+      staging: null,
+      production: null,
+    },
   },
 ] as const;
 

--- a/src/contexts/FeatureFlagsContext.tsx
+++ b/src/contexts/FeatureFlagsContext.tsx
@@ -10,9 +10,15 @@ import {
   useState,
 } from "react";
 import type { DeploymentEnv, FeatureFlagId } from "@/config/featureFlags";
+import {
+  type DatasetIdOverrides,
+  readDatasetOverrides,
+  writeDatasetOverrides,
+} from "@/lib/featureFlags/datasetOverrides";
 import { getDeploymentEnv } from "@/lib/featureFlags/environment";
 import {
   type FeatureFlagOverrides,
+  resolveAllDatasetIds,
   resolveAllFlags,
 } from "@/lib/featureFlags/resolve";
 import { readOverrides, writeOverrides } from "@/lib/featureFlags/storage";
@@ -23,6 +29,9 @@ interface FeatureFlagsContextValue {
   overrides: FeatureFlagOverrides;
   isHydrated: boolean;
   setOverride: (id: FeatureFlagId, value: boolean) => void;
+  datasetIds: Partial<Record<FeatureFlagId, string | null>>;
+  datasetIdOverrides: DatasetIdOverrides;
+  setDatasetOverride: (id: FeatureFlagId, value: string) => void;
 }
 
 const FeatureFlagsContext = createContext<FeatureFlagsContextValue | undefined>(
@@ -32,10 +41,13 @@ const FeatureFlagsContext = createContext<FeatureFlagsContextValue | undefined>(
 export function FeatureFlagsProvider({ children }: { children: ReactNode }) {
   const environment = useMemo(() => getDeploymentEnv(), []);
   const [overrides, setOverrides] = useState<FeatureFlagOverrides>({});
+  const [datasetIdOverrides, setDatasetIdOverrides] =
+    useState<DatasetIdOverrides>({});
   const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
     setOverrides(readOverrides());
+    setDatasetIdOverrides(readDatasetOverrides());
     setIsHydrated(true);
   }, []);
 
@@ -47,14 +59,50 @@ export function FeatureFlagsProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const setDatasetOverride = useCallback((id: FeatureFlagId, value: string) => {
+    setDatasetIdOverrides((previous) => {
+      const next = { ...previous };
+      if (value.trim()) {
+        next[id] = value.trim();
+      } else {
+        delete next[id];
+      }
+      writeDatasetOverrides(next);
+      return next;
+    });
+  }, []);
+
   const flags = useMemo(
     () => resolveAllFlags(environment, overrides),
     [environment, overrides],
   );
 
+  const datasetIds = useMemo(
+    () => resolveAllDatasetIds(environment, datasetIdOverrides),
+    [environment, datasetIdOverrides],
+  );
+
   const value = useMemo(
-    () => ({ environment, flags, overrides, isHydrated, setOverride }),
-    [environment, flags, overrides, isHydrated, setOverride],
+    () => ({
+      environment,
+      flags,
+      overrides,
+      isHydrated,
+      setOverride,
+      datasetIds,
+      datasetIdOverrides,
+      setDatasetOverride,
+    }),
+    [
+      environment,
+      flags,
+      overrides,
+      isHydrated,
+      setOverride,
+      datasetIds,
+      datasetIdOverrides,
+      setDatasetOverride,
+    ],
   );
 
   return (

--- a/src/lib/featureFlags/datasetOverrides.test.tsx
+++ b/src/lib/featureFlags/datasetOverrides.test.tsx
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DATASET_OVERRIDES_STORAGE_KEY,
+  parseDatasetOverrides,
+  readDatasetOverrides,
+  writeDatasetOverrides,
+} from "./datasetOverrides";
+
+describe("parseDatasetOverrides", () => {
+  it("returns empty object for null", () => {
+    expect(parseDatasetOverrides(null)).toEqual({});
+  });
+
+  it("returns empty object for invalid JSON", () => {
+    expect(parseDatasetOverrides("not json")).toEqual({});
+  });
+
+  it("keeps only known flag IDs with string values", () => {
+    const raw = JSON.stringify({
+      pinnedDatasetWeather: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+      pinnedDatasetLanguage: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+      unknownFlag: "some-id",
+      pinnedDatasetMath: 123,
+    });
+    expect(parseDatasetOverrides(raw)).toEqual({
+      pinnedDatasetWeather: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+      pinnedDatasetLanguage: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
+    });
+  });
+});
+
+describe("readDatasetOverrides / writeDatasetOverrides", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns empty object when nothing stored", () => {
+    expect(readDatasetOverrides()).toEqual({});
+  });
+
+  it("round-trips a valid override", () => {
+    writeDatasetOverrides({ pinnedDatasetWeather: "abc-123" });
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(DATASET_OVERRIDES_STORAGE_KEY) ?? "{}",
+      ),
+    ).toMatchObject({ pinnedDatasetWeather: "abc-123" });
+    expect(readDatasetOverrides()).toEqual({ pinnedDatasetWeather: "abc-123" });
+  });
+});

--- a/src/lib/featureFlags/datasetOverrides.ts
+++ b/src/lib/featureFlags/datasetOverrides.ts
@@ -1,0 +1,56 @@
+import { FEATURE_FLAG_IDS, type FeatureFlagId } from "@/config/featureFlags";
+import { isBrowser } from "@/lib/env";
+import { logError } from "@/lib/logger";
+
+export const DATASET_OVERRIDES_STORAGE_KEY = "datagemsDatasetOverrides";
+
+export type DatasetIdOverrides = Partial<Record<FeatureFlagId, string>>;
+
+const KNOWN_IDS = new Set<string>(FEATURE_FLAG_IDS);
+
+export function parseDatasetOverrides(raw: string | null): DatasetIdOverrides {
+  if (!raw) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+
+  const overrides: DatasetIdOverrides = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (KNOWN_IDS.has(key) && typeof value === "string") {
+      overrides[key as FeatureFlagId] = value;
+    }
+  }
+  return overrides;
+}
+
+export function readDatasetOverrides(): DatasetIdOverrides {
+  if (!isBrowser()) return {};
+  try {
+    return parseDatasetOverrides(
+      window.localStorage.getItem(DATASET_OVERRIDES_STORAGE_KEY),
+    );
+  } catch (error) {
+    logError("Failed to read dataset overrides from storage", error);
+    return {};
+  }
+}
+
+export function writeDatasetOverrides(overrides: DatasetIdOverrides): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(
+      DATASET_OVERRIDES_STORAGE_KEY,
+      JSON.stringify(overrides),
+    );
+  } catch (error) {
+    logError("Failed to persist dataset overrides to storage", error);
+  }
+}

--- a/src/lib/featureFlags/resolve.ts
+++ b/src/lib/featureFlags/resolve.ts
@@ -4,6 +4,7 @@ import {
   type FeatureFlagId,
   getFeatureFlagDefinition,
 } from "@/config/featureFlags";
+import type { DatasetIdOverrides } from "@/lib/featureFlags/datasetOverrides";
 
 export type FeatureFlagOverrides = Partial<Record<FeatureFlagId, boolean>>;
 
@@ -25,6 +26,30 @@ export function resolveAllFlags(
   const resolved = {} as Record<FeatureFlagId, boolean>;
   for (const definition of FEATURE_FLAGS) {
     resolved[definition.id] = resolveFlag(definition.id, env, overrides);
+  }
+  return resolved;
+}
+
+export function resolveDatasetId(
+  flagId: FeatureFlagId,
+  env: DeploymentEnv,
+  overrides: DatasetIdOverrides,
+): string | null {
+  const override = overrides[flagId];
+  if (typeof override === "string" && override.trim() !== "") return override;
+  const definition = getFeatureFlagDefinition(flagId);
+  return definition?.defaultDatasetId?.[env] ?? null;
+}
+
+export function resolveAllDatasetIds(
+  env: DeploymentEnv,
+  overrides: DatasetIdOverrides,
+): Partial<Record<FeatureFlagId, string | null>> {
+  const resolved: Partial<Record<FeatureFlagId, string | null>> = {};
+  for (const definition of FEATURE_FLAGS) {
+    if (definition.defaultDatasetId !== undefined) {
+      resolved[definition.id] = resolveDatasetId(definition.id, env, overrides);
+    }
   }
   return resolved;
 }

--- a/tests/featureFlags.test.ts
+++ b/tests/featureFlags.test.ts
@@ -2,10 +2,20 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { FEATURE_FLAGS } from "../src/config/featureFlags";
 import { normalizeDeploymentEnv } from "../src/lib/featureFlags/environment";
-import { resolveAllFlags, resolveFlag } from "../src/lib/featureFlags/resolve";
+import {
+  resolveAllFlags,
+  resolveDatasetId,
+  resolveFlag,
+} from "../src/lib/featureFlags/resolve";
 import { parseOverrides } from "../src/lib/featureFlags/storage";
 
-const DISABLED_EVERYWHERE = new Set(["customCollection", "generalChat"]);
+const DISABLED_EVERYWHERE = new Set([
+  "customCollection",
+  "generalChat",
+  "pinnedDatasetWeather",
+  "pinnedDatasetLanguage",
+  "pinnedDatasetMath",
+]);
 const ENVS = ["playground", "staging", "production"] as const;
 
 test("flags enabled everywhere default to true on every environment", () => {
@@ -76,6 +86,39 @@ test("parseOverrides returns an empty object for null or invalid JSON", () => {
   assert.deepEqual(parseOverrides(null), {});
   assert.deepEqual(parseOverrides("{not json"), {});
   assert.deepEqual(parseOverrides("[1,2,3]"), {});
+});
+
+test("resolveDatasetId returns env default when no override is set", () => {
+  assert.equal(
+    resolveDatasetId("pinnedDatasetWeather", "playground", {}),
+    "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+  );
+  assert.equal(
+    resolveDatasetId("pinnedDatasetWeather", "production", {}),
+    "ecd7c0eb-fbfe-4d61-bfed-df8048f648ed",
+  );
+});
+
+test("resolveDatasetId lets a string override win over the environment default", () => {
+  assert.equal(
+    resolveDatasetId("pinnedDatasetWeather", "playground", {
+      pinnedDatasetWeather: "custom-id",
+    }),
+    "custom-id",
+  );
+});
+
+test("resolveDatasetId returns null for a flag with no defaultDatasetId", () => {
+  assert.equal(resolveDatasetId("datasetPackage", "playground", {}), null);
+});
+
+test("resolveDatasetId falls back to env default when override is empty string", () => {
+  assert.equal(
+    resolveDatasetId("pinnedDatasetWeather", "playground", {
+      pinnedDatasetWeather: "",
+    }),
+    "3166e649-54c1-4ebf-904e-de9a46cb1b18",
+  );
 });
 
 test("parseOverrides keeps only known flag ids with boolean values", () => {


### PR DESCRIPTION
**Release v0.2.0** — sync `develop` into `main` for tagging (branch off `main` carrying develop's content; `git diff develop` = tylko bump wersji).

`package.json`: `0.1.0 → 0.2.0`.

## Zmiany od v0.1.1

### ✨ Features
- **Use-case dataset override via feature flags** (DG-209, #234) — pilotaże mogą wymuszać/nadpisywać, które zbiory pokazują, sterowane przez feature-flagi (nowy moduł `src/lib/featureFlags/datasetOverrides.ts`).

### 🐛 Fixes
- Poprawiony feature-flag **widoczności general chat** (DG-220, #227).
- Przyciski wyboru datasetu respektują flagę **„Hide general chat"** (DG-223, #228).
- Poprawione URL-e przycisku **„Browse Datasets"** na kaflach use-case na Dashboardzie (DG-221, #231).
- Build fix: niezescapowany apostrof na stronie Math home psuł build produkcyjny (DG-230, #235).

### 💅 UI / treści
- **Kafle use-case na Dashboardzie** — zaktualizowane teksty i ujednolicona wysokość (DG-229, #232).
- **Strona główna pilotażu Math** — copy pod przepływ redirectu MathE (DG-230, #233).

## Po zmergowaniu
`gh release create v0.2.0 --target main` z powyższym opisem jako release notes.