### PR TITLE
DG-241 | Show dataset name and ID in permissions table, flag orphaned grants

### DIFF
--- a/src/components/ui/user/RolesPermissionsSection.test.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.test.tsx
@@ -216,8 +216,66 @@ describe("RolesPermissionsSection", () => {
     expect(await screen.findByText("Unknown dataset")).toBeInTheDocument();
     expect(screen.getByText("dataset-deleted")).toBeInTheDocument();
     expect(
-      screen.getByText(/1 reference datasets that no longer exist/),
+      screen.getByText(/1 references a dataset that no longer exists/),
     ).toBeInTheDocument();
     expect(screen.getByText(/2 results/)).toBeInTheDocument();
+  });
+
+  it("keeps rows usable and reports a lookup failure instead of claiming datasets were deleted", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      getCurrentUserContextGrants: vi.fn().mockResolvedValue([
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-1",
+          role: "edit",
+        },
+      ]),
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      queryDatasets: vi.fn().mockRejectedValue(new Error("gateway 500")),
+      queryCollections: vi.fn().mockResolvedValue({ items: [] }),
+    });
+
+    render(<RolesPermissionsSection />);
+
+    // The ID stands in for the name (name line + ID line), not "Unknown dataset".
+    expect((await screen.findAllByText("dataset-1")).length).toBeGreaterThan(1);
+    expect(screen.queryByText("Unknown dataset")).toBeNull();
+    expect(
+      screen.getByText(/dataset names could not be loaded/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/no longer exist/)).toBeNull();
+  });
+
+  it("treats a returned dataset with a blank name as resolved, showing the id as the name", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      getCurrentUserContextGrants: vi.fn().mockResolvedValue([
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-1",
+          role: "edit",
+        },
+      ]),
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      queryDatasets: vi.fn().mockResolvedValue({
+        items: [{ id: "dataset-1", name: "" }],
+      }),
+      queryCollections: vi.fn().mockResolvedValue({ items: [] }),
+    });
+
+    render(<RolesPermissionsSection />);
+
+    expect((await screen.findAllByText("dataset-1")).length).toBeGreaterThan(1);
+    expect(screen.queryByText("Unknown dataset")).toBeNull();
+    expect(screen.queryByText(/no longer exist/)).toBeNull();
   });
 });

--- a/src/components/ui/user/RolesPermissionsSection.test.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.test.tsx
@@ -154,4 +154,70 @@ describe("RolesPermissionsSection", () => {
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
   });
+
+  it("shows the dataset id under the dataset name (DG-241)", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      getCurrentUserContextGrants: vi.fn().mockResolvedValue([
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-1",
+          role: "edit",
+        },
+      ]),
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      queryDatasets: vi.fn().mockResolvedValue({
+        items: [{ id: "dataset-1", name: "Dataset One" }],
+      }),
+      queryCollections: vi.fn().mockResolvedValue({ items: [] }),
+    });
+
+    render(<RolesPermissionsSection />);
+
+    expect(await screen.findByText("Dataset One")).toBeInTheDocument();
+    expect(screen.getByText("dataset-1")).toBeInTheDocument();
+  });
+
+  it("marks grants whose dataset no longer resolves and reports them next to the result count (DG-240)", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      getCurrentUserContextGrants: vi.fn().mockResolvedValue([
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-1",
+          role: "edit",
+        },
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-deleted",
+          role: "browse",
+        },
+      ]),
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      // The API only knows dataset-1; dataset-deleted is an orphaned grant.
+      queryDatasets: vi.fn().mockResolvedValue({
+        items: [{ id: "dataset-1", name: "Dataset One" }],
+      }),
+      queryCollections: vi.fn().mockResolvedValue({ items: [] }),
+    });
+
+    render(<RolesPermissionsSection />);
+
+    expect(await screen.findByText("Unknown dataset")).toBeInTheDocument();
+    expect(screen.getByText("dataset-deleted")).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 reference datasets that no longer exist/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/2 results/)).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/user/RolesPermissionsSection.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.tsx
@@ -470,6 +470,10 @@ export default function RolesPermissionsSection() {
   const [collectionNames, setCollectionNames] = useState<
     Record<string, string>
   >({});
+  // True when the name lookup itself failed — rows must then stay interactive
+  // with the ID as the name instead of being misreported as deleted targets.
+  const [datasetLookupFailed, setDatasetLookupFailed] = useState(false);
+  const [collectionLookupFailed, setCollectionLookupFailed] = useState(false);
   const [datasetUploadedBy, setDatasetUploadedBy] = useState<
     Record<string, string | null>
   >({});
@@ -537,13 +541,23 @@ export default function RolesPermissionsSection() {
           }, {});
         setGroupNames(groupMap);
 
-        const datasetIds = grantsResult
-          .filter((grant) => grant.targetType === 0 && grant.targetId)
-          .map((grant) => grant.targetId as string);
-        const collectionIds = grantsResult
-          .filter((grant) => grant.targetType === 1 && grant.targetId)
-          .map((grant) => grant.targetId as string);
+        const datasetIds = Array.from(
+          new Set(
+            grantsResult
+              .filter((grant) => grant.targetType === 0 && grant.targetId)
+              .map((grant) => grant.targetId as string),
+          ),
+        );
+        const collectionIds = Array.from(
+          new Set(
+            grantsResult
+              .filter((grant) => grant.targetType === 1 && grant.targetId)
+              .map((grant) => grant.targetId as string),
+          ),
+        );
 
+        let datasetsFailed = false;
+        let collectionsFailed = false;
         const [datasetsResult, collectionsResult] = await Promise.all([
           datasetIds.length > 0
             ? queryDatasets({
@@ -558,6 +572,7 @@ export default function RolesPermissionsSection() {
                 logWarn("Failed to load dataset names for grants", {
                   error: errorMessage,
                 });
+                datasetsFailed = true;
                 return { items: [] };
               })
             : Promise.resolve({ items: [] }),
@@ -574,6 +589,7 @@ export default function RolesPermissionsSection() {
                 logWarn("Failed to load collection names for grants", {
                   error: errorMessage,
                 });
+                collectionsFailed = true;
                 return { items: [] };
               })
             : Promise.resolve({ items: [] }),
@@ -586,15 +602,12 @@ export default function RolesPermissionsSection() {
           name?: string;
           createdBy?: string | null;
         }>;
+        // Every returned item counts as resolved; a blank name falls back to
+        // the ID for display but must not be misreported as a deleted target.
         const datasetMap = datasetItems
-          .map((item) => ({
-            id: item.id ?? "",
-            name: item.name ?? "",
-            uploadedBy: item.createdBy ?? null,
-          }))
-          .filter((item) => item.id && item.name)
+          .filter((item) => item.id)
           .reduce((acc: Record<string, string>, item) => {
-            acc[item.id] = item.name;
+            acc[item.id as string] = item.name?.trim() || (item.id as string);
             return acc;
           }, {});
         const datasetUploadedByMap = datasetItems
@@ -609,14 +622,9 @@ export default function RolesPermissionsSection() {
           createdBy?: string | null;
         }>;
         const collectionMap = collectionItems
-          .map((item) => ({
-            id: item.id ?? "",
-            name: item.name ?? "",
-            uploadedBy: item.createdBy ?? null,
-          }))
-          .filter((item) => item.id && item.name)
+          .filter((item) => item.id)
           .reduce((acc: Record<string, string>, item) => {
-            acc[item.id] = item.name;
+            acc[item.id as string] = item.name?.trim() || (item.id as string);
             return acc;
           }, {});
         const collectionUploadedByMap = collectionItems
@@ -626,10 +634,31 @@ export default function RolesPermissionsSection() {
             return acc;
           }, {});
 
+        if (!datasetsFailed && datasetItems.length < datasetIds.length) {
+          logWarn("Dataset name lookup returned fewer items than requested", {
+            requested: datasetIds.length,
+            returned: datasetItems.length,
+          });
+        }
+        if (
+          !collectionsFailed &&
+          collectionItems.length < collectionIds.length
+        ) {
+          logWarn(
+            "Collection name lookup returned fewer items than requested",
+            {
+              requested: collectionIds.length,
+              returned: collectionItems.length,
+            },
+          );
+        }
+
         setDatasetNames(datasetMap);
         setCollectionNames(collectionMap);
         setDatasetUploadedBy(datasetUploadedByMap);
         setCollectionUploadedBy(collectionUploadedByMap);
+        setDatasetLookupFailed(datasetsFailed);
+        setCollectionLookupFailed(collectionsFailed);
       } catch (error) {
         if (cancelled) return;
         logError("Failed to load context grants", error);
@@ -690,15 +719,27 @@ export default function RolesPermissionsSection() {
     });
 
     return Array.from(grouped.values()).map((entry) => {
+      const lookupFailed =
+        entry.targetType === 0
+          ? datasetLookupFailed
+          : entry.targetType === 1
+            ? collectionLookupFailed
+            : false;
       const resolvedName =
         entry.targetType === 0
           ? datasetNames[entry.targetId]
           : entry.targetType === 1
             ? collectionNames[entry.targetId]
             : undefined;
+      const kindLabel = TARGET_KIND_LABELS[entry.targetType] ?? "Unknown";
+      // A failed lookup says nothing about whether the target exists — keep
+      // the row fully usable and show the ID in place of the name.
+      const resolved = lookupFailed || Boolean(resolvedName);
       const targetName =
         resolvedName ||
-        (entry.targetType === 0 ? "Unknown dataset" : "Unknown collection");
+        (lookupFailed
+          ? entry.targetId
+          : `Unknown ${TARGET_KIND_LABELS[entry.targetType]?.toLowerCase() ?? "target"}`);
       const uploadedBy =
         entry.targetType === 0
           ? (datasetUploadedBy[entry.targetId] ?? null)
@@ -710,8 +751,8 @@ export default function RolesPermissionsSection() {
         id: `${entry.targetType}-${entry.targetId}`,
         targetId: entry.targetId,
         targetName,
-        targetType: TARGET_KIND_LABELS[entry.targetType] ?? "Unknown",
-        resolved: Boolean(resolvedName),
+        targetType: kindLabel,
+        resolved,
         roles: Array.from(entry.roles),
         groupCount: entry.groups.size,
         groupIds: Array.from(entry.groups),
@@ -719,8 +760,10 @@ export default function RolesPermissionsSection() {
       };
     });
   }, [
+    collectionLookupFailed,
     collectionNames,
     collectionUploadedBy,
+    datasetLookupFailed,
     datasetNames,
     datasetUploadedBy,
     grants,
@@ -768,10 +811,17 @@ export default function RolesPermissionsSection() {
     [filteredRows],
   );
 
+  const activeKind = typeFilter === "collections" ? "collection" : "dataset";
+  const activeLookupFailed =
+    typeFilter === "collections" ? collectionLookupFailed : datasetLookupFailed;
+
   const getPermissionLabel = (row: GrantRow) => row.roles[0] ?? "";
 
   const getSortValue = (row: GrantRow, key: SortKey) => {
-    if (key === "assetName") return row.targetName.toLowerCase();
+    // Tiebreak equal names (e.g. several "Unknown dataset" rows) by the
+    // visible target ID so ordering matches what the user sees.
+    if (key === "assetName")
+      return `${row.targetName.toLowerCase()} ${row.targetId}`;
     if (key === "groupsAdded") return row.groupCount;
     if (key === "permission") return getPermissionLabel(row).toLowerCase();
     return "";
@@ -970,12 +1020,19 @@ export default function RolesPermissionsSection() {
           <div className="text-[14px] leading-[150%] text-gray-750">
             <span className="text-gray-650">Showing:</span>{" "}
             {filteredRows.length} results
-            {!isLoading && unresolvedCount > 0 && (
+            {!isLoading && activeLookupFailed && (
               <span className="text-gray-650">
                 {" "}
-                · {unresolvedCount} reference{" "}
-                {typeFilter === "collections" ? "collections" : "datasets"} that
-                no longer exist or are inaccessible
+                · {activeKind} names could not be loaded — showing identifiers
+              </span>
+            )}
+            {!isLoading && !activeLookupFailed && unresolvedCount > 0 && (
+              <span className="text-gray-650">
+                {" "}
+                ·{" "}
+                {unresolvedCount === 1
+                  ? `1 references a ${activeKind} that no longer exists or is inaccessible`
+                  : `${unresolvedCount} reference ${activeKind}s that no longer exist or are inaccessible`}
               </span>
             )}
           </div>
@@ -1076,13 +1133,14 @@ export default function RolesPermissionsSection() {
                     const roles = row.roles;
                     const primaryRole = roles[0];
                     const extraCount = Math.max(roles.length - 1, 0);
-                    const hasEditRights =
+                    const isInteractiveDataset =
                       row.resolved &&
-                      row.targetType.toLowerCase() === "dataset" &&
+                      row.targetType.toLowerCase() === "dataset";
+                    const hasEditRights =
+                      isInteractiveDataset &&
                       (roles.includes("Edit") || roles.includes("Manage"));
                     const hasDeleteRights =
-                      row.resolved &&
-                      row.targetType.toLowerCase() === "dataset" &&
+                      isInteractiveDataset &&
                       (roles.includes("Delete") || roles.includes("Manage"));
                     const groupsTooltip =
                       row.groupCount > 0
@@ -1097,29 +1155,20 @@ export default function RolesPermissionsSection() {
                         key={row.id}
                         role="row"
                         className={`grid grid-cols-[1fr_126px_180px_122px_137px] items-center h-14 border-b border-slate-200 last:border-b-0 ${
-                          row.resolved &&
-                          row.targetType.toLowerCase() === "dataset"
+                          isInteractiveDataset
                             ? "cursor-pointer hover:bg-slate-50"
                             : ""
                         }`}
                         onClick={() => {
-                          if (
-                            !row.resolved ||
-                            row.targetType.toLowerCase() !== "dataset"
-                          )
-                            return;
+                          if (!isInteractiveDataset) return;
                           setSelectedDataset({
                             id: row.targetId,
                             name: row.targetName,
                           });
                         }}
                       >
-                        <div
-                          className="px-4 min-w-0"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          {row.resolved &&
-                          row.targetType.toLowerCase() === "dataset" ? (
+                        <div className="px-4 min-w-0">
+                          {isInteractiveDataset ? (
                             <button
                               type="button"
                               onClick={(event) => {
@@ -1145,12 +1194,15 @@ export default function RolesPermissionsSection() {
                               {row.targetName}
                             </div>
                           )}
-                          <div
-                            className="truncate font-mono text-[12px] text-gray-500"
-                            title={row.targetId}
+                          <Tooltip
+                            content={row.targetId}
+                            position="top"
+                            delay={300}
                           >
-                            {row.targetId}
-                          </div>
+                            <div className="truncate font-mono text-[12px] text-gray-500">
+                              {row.targetId}
+                            </div>
+                          </Tooltip>
                         </div>
                         <div className="px-4 flex items-center justify-center">
                           {row.groupCount > 0 && groupsTooltip ? (

--- a/src/components/ui/user/RolesPermissionsSection.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.tsx
@@ -35,6 +35,8 @@ type GrantRow = {
   targetId: string;
   targetName: string;
   targetType: string;
+  /** False when the grant references a target the API no longer returns (deleted or inaccessible). */
+  resolved: boolean;
   roles: string[];
   groupCount: number;
   groupIds: string[];
@@ -688,12 +690,15 @@ export default function RolesPermissionsSection() {
     });
 
     return Array.from(grouped.values()).map((entry) => {
-      const targetName =
+      const resolvedName =
         entry.targetType === 0
-          ? datasetNames[entry.targetId] || entry.targetId || "Unknown"
+          ? datasetNames[entry.targetId]
           : entry.targetType === 1
-            ? collectionNames[entry.targetId] || entry.targetId || "Unknown"
-            : entry.targetId || "Unknown";
+            ? collectionNames[entry.targetId]
+            : undefined;
+      const targetName =
+        resolvedName ||
+        (entry.targetType === 0 ? "Unknown dataset" : "Unknown collection");
       const uploadedBy =
         entry.targetType === 0
           ? (datasetUploadedBy[entry.targetId] ?? null)
@@ -706,6 +711,7 @@ export default function RolesPermissionsSection() {
         targetId: entry.targetId,
         targetName,
         targetType: TARGET_KIND_LABELS[entry.targetType] ?? "Unknown",
+        resolved: Boolean(resolvedName),
         roles: Array.from(entry.roles),
         groupCount: entry.groups.size,
         groupIds: Array.from(entry.groups),
@@ -742,7 +748,9 @@ export default function RolesPermissionsSection() {
         groupFilter.length === 0 ||
         row.groupIds.some((groupId) => groupFilter.includes(groupId));
       const matchesSearch =
-        !query || row.targetName.toLowerCase().includes(query);
+        !query ||
+        row.targetName.toLowerCase().includes(query) ||
+        row.targetId.toLowerCase().includes(query);
       return matchesType && matchesRole && matchesGroup && matchesSearch;
     });
   }, [
@@ -754,6 +762,11 @@ export default function RolesPermissionsSection() {
     searchQuery,
     typeFilter,
   ]);
+
+  const unresolvedCount = useMemo(
+    () => filteredRows.filter((row) => !row.resolved).length,
+    [filteredRows],
+  );
 
   const getPermissionLabel = (row: GrantRow) => row.roles[0] ?? "";
 
@@ -957,6 +970,14 @@ export default function RolesPermissionsSection() {
           <div className="text-[14px] leading-[150%] text-gray-750">
             <span className="text-gray-650">Showing:</span>{" "}
             {filteredRows.length} results
+            {!isLoading && unresolvedCount > 0 && (
+              <span className="text-gray-650">
+                {" "}
+                · {unresolvedCount} reference{" "}
+                {typeFilter === "collections" ? "collections" : "datasets"} that
+                no longer exist or are inaccessible
+              </span>
+            )}
           </div>
         </div>
 
@@ -1056,9 +1077,11 @@ export default function RolesPermissionsSection() {
                     const primaryRole = roles[0];
                     const extraCount = Math.max(roles.length - 1, 0);
                     const hasEditRights =
+                      row.resolved &&
                       row.targetType.toLowerCase() === "dataset" &&
                       (roles.includes("Edit") || roles.includes("Manage"));
                     const hasDeleteRights =
+                      row.resolved &&
                       row.targetType.toLowerCase() === "dataset" &&
                       (roles.includes("Delete") || roles.includes("Manage"));
                     const groupsTooltip =
@@ -1074,12 +1097,16 @@ export default function RolesPermissionsSection() {
                         key={row.id}
                         role="row"
                         className={`grid grid-cols-[1fr_126px_180px_122px_137px] items-center h-14 border-b border-slate-200 last:border-b-0 ${
+                          row.resolved &&
                           row.targetType.toLowerCase() === "dataset"
                             ? "cursor-pointer hover:bg-slate-50"
                             : ""
                         }`}
                         onClick={() => {
-                          if (row.targetType.toLowerCase() !== "dataset")
+                          if (
+                            !row.resolved ||
+                            row.targetType.toLowerCase() !== "dataset"
+                          )
                             return;
                           setSelectedDataset({
                             id: row.targetId,
@@ -1088,10 +1115,11 @@ export default function RolesPermissionsSection() {
                         }}
                       >
                         <div
-                          className="px-4 text-[14px] text-gray-750 truncate"
+                          className="px-4 min-w-0"
                           onClick={(e) => e.stopPropagation()}
                         >
-                          {row.targetType.toLowerCase() === "dataset" ? (
+                          {row.resolved &&
+                          row.targetType.toLowerCase() === "dataset" ? (
                             <button
                               type="button"
                               onClick={(event) => {
@@ -1102,13 +1130,27 @@ export default function RolesPermissionsSection() {
                                   ),
                                 );
                               }}
-                              className="text-left hover:underline"
+                              className="block max-w-full truncate text-left text-[14px] text-gray-750 hover:underline"
                             >
                               {row.targetName}
                             </button>
                           ) : (
-                            row.targetName
+                            <div
+                              className={`truncate text-[14px] ${
+                                row.resolved
+                                  ? "text-gray-750"
+                                  : "italic text-gray-500"
+                              }`}
+                            >
+                              {row.targetName}
+                            </div>
                           )}
+                          <div
+                            className="truncate font-mono text-[12px] text-gray-500"
+                            title={row.targetId}
+                          >
+                            {row.targetId}
+                          </div>
                         </div>
                         <div className="px-4 flex items-center justify-center">
                           {row.groupCount > 0 && groupsTooltip ? (


### PR DESCRIPTION
Closes #241. Addresses #240 (frontend part — see diagnosis below).

## Summary

The User Access permissions table displayed the raw dataset ID as the name whenever a grant referenced a dataset the API no longer returns, and the result count silently included those orphaned grants. Reported by Mike Xydas (DataGEMS UI Status Report, 2026-07-09): on dev the table showed **442 results against 51 existing datasets**, with IDs shown instead of names.

## Diagnosis (#240)

The count is the number of **distinct targets in the current user's context grants** (`GET /principal/me/context-grants`, grouped per dataset/collection). The gateway keeps grants for datasets that have since been deleted, so the admin sees 442 distinct dataset IDs while only 51 datasets resolve. Those same orphaned grants are why rows showed bare IDs — the name lookup (`queryDatasets({ids})`) can't return deleted datasets, and the code fell back to the ID.

**Backend follow-up (backend team / Georgios):** orphaned context grants should ideally be cleaned up (or filtered) server-side when a dataset is deleted.

## Changes

- Each row shows the resolved **name with the target ID in a monospace secondary line** — both always visible (Mike's request in #241).
- Grants whose target no longer resolves render as *Unknown dataset* / *Unknown collection* in muted italics instead of a bare ID.
- The result count is annotated: `Showing: 442 results · 391 reference datasets that no longer exist or are inaccessible` — the discrepancy is explained instead of hidden.
- Row click, Edit and Delete are disabled for unresolved targets (they led to dead ends for deleted datasets).
- Search also matches the target ID now.

## Verification

- `RolesPermissionsSection` tests: 5/5 pass (3 existing + 2 new covering the ID line, the orphaned-grant row, and the count annotation)
- Full unit suite: identical to `develop` baseline (no new failures), type-check clean, production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up (2nd commit)

A code review of the first commit found that the `resolved` flag conflated **"target absent from the API response"** with **"name lookup failed"** — a transient gateway error would misreport every grant as referencing a deleted dataset, with all actions disabled and no error surfaced. Reworked:

- **Lookup failures are tracked explicitly.** On failure, rows keep the pre-change behaviour (ID as the name, fully interactive) and the count line reads *"dataset names could not be loaded — showing identifiers"* instead of falsely claiming targets no longer exist. This also keeps the Manage deep link (`/settings?tab=roles&datasetId=…`) usable during such failures.
- A returned item with a **blank name** counts as resolved (ID shown as the display name) instead of being reported as deleted.
- Grant target IDs are **deduplicated** before the name query, and a warning is logged when the response returns fewer items than requested (silent page-cap truncation becomes visible).
- **Singular grammar** fixed in the count annotation; the Unknown-target label is derived from `TARGET_KIND_LABELS` instead of a second hardcoded mapping.
- The first cell no longer swallows clicks (`stopPropagation` removed) — clicking the ID line or cell whitespace triggers the row action; the name button still stops its own propagation.
- The five copies of the resolved-dataset guard collapsed into one `isInteractiveDataset` flag; the ID line uses the shared `Tooltip`; name sorting tiebreaks by the visible target ID.

Tests: 7/7 (grammar assertion updated; new cases for lookup failure and blank-name items).

