### PR TITLE
DG-242 | Enable dataset permission editing; surface server rejections

### DIFF
--- a/src/components/ui/user/DatasetPermissionsModal.test.tsx
+++ b/src/components/ui/user/DatasetPermissionsModal.test.tsx
@@ -1,11 +1,13 @@
 import {
   fireEvent,
-  render,
+  render as rtlRender,
   screen,
   waitFor,
   within,
 } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { ErrorProvider } from "@/contexts/ErrorContext";
 import { DatasetPermissionsModal } from "./DatasetPermissionsModal";
 
 const mockUseApi = vi.fn();
@@ -13,6 +15,10 @@ const mockUseApi = vi.fn();
 vi.mock("@/hooks/useApi", () => ({
   useApi: () => mockUseApi(),
 }));
+
+// The modal reports API failures through the ErrorContext toast.
+const render = (ui: ReactElement) =>
+  rtlRender(<ErrorProvider>{ui}</ErrorProvider>);
 
 describe("DatasetPermissionsModal", () => {
   it("updates group permissions via context grants", async () => {
@@ -107,7 +113,7 @@ describe("DatasetPermissionsModal", () => {
     );
 
     fireEvent.click(await screen.findByText("Invite by E-mail"));
-    const emailInput = screen.getByPlaceholderText("Enter e-mail");
+    const emailInput = screen.getByPlaceholderText("Email address");
     fireEvent.change(emailInput, { target: { value: "ada@example.com" } });
     fireEvent.click(screen.getByText("Invite"));
 
@@ -126,6 +132,47 @@ describe("DatasetPermissionsModal", () => {
         "dg_ds-download",
       );
     });
+  });
+
+  it("shows an error toast and keeps the switch state when the server rejects the change", async () => {
+    const assignGroupDatasetGrant = vi
+      .fn()
+      .mockRejectedValue(new Error("403 Forbidden"));
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      getGroupDatasetGrants: vi.fn().mockResolvedValue({ "dataset-1": [] }),
+      assignGroupDatasetGrant,
+      unassignGroupDatasetGrant: vi.fn().mockResolvedValue(undefined),
+      queryUsers: vi.fn().mockResolvedValue({ items: [] }),
+      getUserDatasetGrants: vi.fn().mockResolvedValue({}),
+      assignUserDatasetGrant: vi.fn().mockResolvedValue(undefined),
+      unassignUserDatasetGrant: vi.fn().mockResolvedValue(undefined),
+    });
+
+    render(
+      <DatasetPermissionsModal
+        isOpen
+        datasetId="dataset-1"
+        datasetName="Dataset One"
+        onClose={vi.fn()}
+      />,
+    );
+
+    const browseToggle = await screen.findByLabelText("Research Team Browse");
+    expect(browseToggle).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(browseToggle);
+
+    await waitFor(() => {
+      expect(assignGroupDatasetGrant).toHaveBeenCalled();
+      expect(
+        screen.getByText(/server rejected the permission change/i),
+      ).toBeInTheDocument();
+    });
+    expect(browseToggle).toHaveAttribute("aria-pressed", "false");
   });
 
   it("filters groups with Manage Groups selection", async () => {

--- a/src/components/ui/user/DatasetPermissionsModal.tsx
+++ b/src/components/ui/user/DatasetPermissionsModal.tsx
@@ -10,6 +10,7 @@ import {
   mapRolesToPermissions,
   type PermissionKey,
 } from "@/config/contextGrantRoles";
+import { useError } from "@/contexts/ErrorContext";
 import { useApi } from "@/hooks/useApi";
 import { logError, logWarn } from "@/lib/logger";
 import { ManageGroupsModal } from "./ManageGroupsModal";
@@ -42,7 +43,6 @@ interface DatasetPermissionsModalProps {
   datasetId: string;
   datasetName: string;
   onClose: () => void;
-  hasManageRights?: boolean;
 }
 
 function PermissionSwitch({
@@ -77,9 +77,9 @@ export function DatasetPermissionsModal({
   datasetId,
   datasetName,
   onClose,
-  hasManageRights = false,
 }: DatasetPermissionsModalProps) {
   const api = useApi();
+  const { showError } = useError();
   const {
     hasToken,
     queryUserGroups,
@@ -228,6 +228,9 @@ export function DatasetPermissionsModal({
       );
     } catch (error) {
       logError("Failed to update group permission", error);
+      showError(
+        "The server rejected the permission change. You may not have manage rights for this dataset.",
+      );
     }
   };
 
@@ -260,6 +263,9 @@ export function DatasetPermissionsModal({
       );
     } catch (error) {
       logError("Failed to update user permission", error);
+      showError(
+        "The server rejected the permission change. You may not have manage rights for this dataset.",
+      );
     }
   };
 
@@ -284,6 +290,9 @@ export function DatasetPermissionsModal({
       );
     } catch (error) {
       logError("Failed to revoke group access", error);
+      showError(
+        "The server rejected revoking access. You may not have manage rights for this dataset.",
+      );
     } finally {
       setRevokeGroupId(null);
     }
@@ -451,7 +460,7 @@ export function DatasetPermissionsModal({
                                   <PermissionSwitch
                                     checked={row.permissions[column.key]}
                                     ariaLabel={`${row.name} ${column.label}`}
-                                    disabled={isLoading || !hasManageRights}
+                                    disabled={isLoading}
                                     onChange={() =>
                                       handleGroupToggle(
                                         row.id,
@@ -463,7 +472,7 @@ export function DatasetPermissionsModal({
                                 </div>
                               ))}
                             </div>
-                            {hasManageRights && hasAnyPermission && (
+                            {hasAnyPermission && (
                               <button
                                 type="button"
                                 className="ml-2 text-[14px] text-red-550 hover:underline"
@@ -557,6 +566,7 @@ export function DatasetPermissionsModal({
                             setInviteEmail("");
                           } catch (error) {
                             logError("Failed to lookup invite user", error);
+                            showError("Failed to look up the invited user.");
                           } finally {
                             setIsInviteLookupLoading(false);
                           }

--- a/src/components/ui/user/RolesPermissionsSection.test.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render as rtlRender, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { ErrorProvider } from "@/contexts/ErrorContext";
 import RolesPermissionsSection from "./RolesPermissionsSection";
 
 const mockUseApi = vi.fn();
@@ -8,6 +10,10 @@ const mockPush = vi.fn();
 vi.mock("@/hooks/useApi", () => ({
   useApi: () => mockUseApi(),
 }));
+
+// The embedded DatasetPermissionsModal reports failures via ErrorContext.
+const render = (ui: ReactElement) =>
+  rtlRender(<ErrorProvider>{ui}</ErrorProvider>);
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),

--- a/src/components/ui/user/RolesPermissionsSection.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.tsx
@@ -1223,15 +1223,6 @@ export default function RolesPermissionsSection() {
         datasetId={selectedDataset?.id ?? ""}
         datasetName={selectedDataset?.name ?? "Dataset permissions"}
         onClose={() => setSelectedDataset(null)}
-        hasManageRights={Boolean(
-          selectedDataset &&
-            grants.some(
-              (g) =>
-                g.targetId === selectedDataset.id &&
-                g.targetType === 0 &&
-                (g.role?.toLowerCase().includes("manage") ?? false),
-            ),
-        )}
       />
       <ConfirmationModal
         isVisible={Boolean(deleteConfirmDataset)}


### PR DESCRIPTION
Closes #242.

## Summary

Admins could not edit dataset permissions: every switch in the permissions modal was disabled unless the current user's **own context grants** contained an explicit `manage` role for that dataset. Admin rights come from a global role, not per-dataset grants, so an admin saw a fully disabled grid (reported by Mike Xydas, DataGEMS UI Status Report, 2026-07-09). On top of that, rejected API calls were swallowed silently — a failing toggle simply didn't move, with no feedback.

Notably, the repository's own test suite documented the expected behaviour: `DatasetPermissionsModal.test.tsx` ("updates group permissions via context grants") renders the modal **without** any manage-rights prop and expects toggling to call the grant API — that test had been failing on `develop` since the lockout was introduced. This PR makes it pass again.

## Changes

- **Client-side `hasManageRights` lockout removed** (modal + its computation in `RolesPermissionsSection`). The gateway is the authority on who may manage grants — the UI attempts the change and reflects the server's answer instead of guessing authorization client-side.
- **Server rejections are surfaced**: failed assign/unassign/revoke calls and invite lookups now show an ErrorContext toast ("The server rejected the permission change. You may not have manage rights for this dataset."). Switch state still updates only on success, so the UI never lies about the outcome.
- **Test maintenance**: fixed the stale invite-test placeholder (`Enter e-mail` → `Email address`), wrapped renders in `ErrorProvider`, added coverage for the rejection toast (switch stays off, toast appears).

## Notes for review

- "Make a dataset public" remains part of the dataset **edit flow** (open/restricted visibility in the onboarding form) — not this modal.
- Whether the gateway authorizes admins on `/principal/context-grants/...` endpoints is the backend half of #242's acceptance criteria (backend team / Georgios). With this change the UI will demonstrate the answer either way: the toggle works, or the admin sees the server's rejection.

## Verification

- `src/components/ui/user` tests: 14/14 pass, including the two modal tests that were failing on `develop`
- Full unit suite: 60 failures vs 62 on `develop` baseline (two pre-existing failures fixed, none added), type-check clean, production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
