### PR TITLE
DG-239 | Enable Weather and Language dataset pins by default

### DIFF
--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -94,7 +94,10 @@ export const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = [
   {
     id: "pinnedDatasetWeather",
     label: "Use case – Weather - Dataset ID",
-    defaults: disabledEverywhere(),
+    // DG-239: pinning must work out of the box — with the flag off it only
+    // activated for browsers with a manual override, so reviewers saw no
+    // ERA5-Land auto-selected while testers with the override did.
+    defaults: enabledEverywhere(),
     defaultDatasetId: {
       playground: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
       staging: "3166e649-54c1-4ebf-904e-de9a46cb1b18",
@@ -104,7 +107,9 @@ export const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = [
   {
     id: "pinnedDatasetLanguage",
     label: "Use case – Language - Dataset ID",
-    defaults: disabledEverywhere(),
+    // DG-239: see pinnedDatasetWeather — enabled so the Britannica pin
+    // applies without a per-browser override.
+    defaults: enabledEverywhere(),
     defaultDatasetId: {
       playground: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",
       staging: "d84d1a2e-127d-4393-91d0-afb7e4fd9c68",

--- a/tests/featureFlags.test.ts
+++ b/tests/featureFlags.test.ts
@@ -12,8 +12,6 @@ import { parseOverrides } from "../src/lib/featureFlags/storage";
 const DISABLED_EVERYWHERE = new Set([
   "customCollection",
   "generalChat",
-  "pinnedDatasetWeather",
-  "pinnedDatasetLanguage",
   "pinnedDatasetMath",
 ]);
 const ENVS = ["playground", "staging", "production"] as const;
@@ -29,6 +27,15 @@ test("customCollection and generalChat default to false on every environment", (
   for (const env of ENVS) {
     assert.equal(resolveFlag("customCollection", env, {}), false);
     assert.equal(resolveFlag("generalChat", env, {}), false);
+  }
+});
+
+test("weather and language dataset pins are enabled by default (DG-239)", () => {
+  for (const env of ENVS) {
+    assert.equal(resolveFlag("pinnedDatasetWeather", env, {}), true);
+    assert.equal(resolveFlag("pinnedDatasetLanguage", env, {}), true);
+    // Math has no default dataset id yet, so its pin stays off.
+    assert.equal(resolveFlag("pinnedDatasetMath", env, {}), false);
   }
 });
 


### PR DESCRIPTION
Refs #239.

## Summary

Mike reported (in #239) that no ERA5-Land dataset is auto-selected in the Weather pilot on dev or prod, even though the issue had been verified as fixed. Both observations were correct: **the pinning only worked in browsers where someone had manually enabled the flag.**

The `pinnedDatasetWeather` / `pinnedDatasetLanguage` feature flags default to *disabled* in every environment; the per-environment dataset IDs (ERA5-Land on prod, Britannica for Language) are configured but inert until the flag is toggled per browser in the flags manager (localStorage). Whoever verified the fix had that override set; a fresh session falls back to the Meteo collection with nothing pinned.

## Change

- `pinnedDatasetWeather` and `pinnedDatasetLanguage` now default to **enabled** in every environment (one line each; the default dataset IDs were already in place).
- `pinnedDatasetMath` stays off — it has no default dataset ID.
- Flag-policy tests updated with an explicit DG-239 case.

## Verification

- Flag policy tests: 16/16 pass; full unit suite identical to the `develop` baseline (one unrelated flaky test appeared in a single run and passes in isolation and on re-run); type-check clean; production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
