### PR TITLE
DG-215 | Add commit-SHA image tag for per-commit deployments

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,6 +76,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
             type=ref,event=tag
+            type=sha,prefix=sha-,format=short
 
       - name: Build and push Docker image for dg-app-ui
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83


### PR DESCRIPTION
Adds `type=sha,prefix=sha-,format=short` to the docker metadata tags, so **every build also gets an immutable `sha-<short>` tag** (e.g. `ghcr.io/datagems-eosc/dg-app-ui:sha-ab12cd3`) alongside the existing `latest`/`develop`/`vX.Y.Z` tags.

## Why
Enables deploying a **specific, reproducible build without cutting a version release or editing code** — e.g. `kubectl set image … dg-app-ui:sha-ab12cd3` (via the new `deploy.sh` in the deployment repos). Immutable per-commit tags are safer/more auditable than `latest`.

No behavior change to existing tags.