### PR TITLE
DG-255 | Remove Similarity column from Retrieved Texts module

### DIFF
--- a/src/app/use-case/language/analysis/page.tsx
+++ b/src/app/use-case/language/analysis/page.tsx
@@ -26,7 +26,6 @@ interface CollocationRow {
 
 interface RetrievedTextRow {
   content: string;
-  similarity: number;
 }
 
 interface AnalysisState {
@@ -145,7 +144,6 @@ function mapResponse(
     .slice(0, 10)
     .map((r) => ({
       content: String(r.content),
-      similarity: Number(r.similarity ?? 0),
     }));
 
   return { termFreqData, sentimentData, collocationData, retrievedTexts };
@@ -460,9 +458,6 @@ export default function LanguageAnalysisPage() {
                   <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
                     Text
                   </th>
-                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
-                    Similarity
-                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-[#e2e8f0]">
@@ -473,9 +468,6 @@ export default function LanguageAnalysisPage() {
                     </td>
                     <td className="py-3 text-[14px] font-medium text-[#314158]">
                       {row.content}
-                    </td>
-                    <td className="py-3 text-[14px] text-[#314158] text-right align-top">
-                      {row.similarity.toFixed(4)}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
Closes #255.

## Summary

Removes the **Similarity** column from the **Retrieved Texts** table on the Language Analysis subpage (`/use-case/language/analysis`). The table now renders only the `#` index and `Text` columns, with `Text` expanding to fill the remaining module width.

## Changes

- Dropped the `Similarity` `<th>` header and the `<td>` cell bound to `rag_output.results[i].similarity`.
- Removed the now-unused `similarity` field from the `RetrievedTextRow` model and its mapping.
- **Top-10 ordering preserved** — the sort still runs on the raw RAG results (`rag_output.results`) by similarity before slicing, so the list content and order are unchanged; only the column is gone.
- `Text` fills the remaining width automatically: `#` keeps its fixed `w-10`, `Text` has no width constraint under `table.w-full`.

## Verification

- Type-check clean; Biome clean; unit tests 104/104 pass (pre-commit hook).
- Dev server compiles `/use-case/language/analysis` → HTTP 200, no errors.
- Full UX flow (login → query → Start Analysis) not driven headlessly (requires auth + sessionStorage payload); table structure verified in source.

