### PR TITLE
DG-182 | Remove hardcoded text from Dataset Details (Specification & Use-Cases)

### DIFF
--- a/src/components/DatasetDetailsPage/DatasetSpecificationSection/DatasetSpecificationSection.module.scss
+++ b/src/components/DatasetDetailsPage/DatasetSpecificationSection/DatasetSpecificationSection.module.scss
@@ -40,4 +40,9 @@
     @include text-secondary;
     flex: 1;
   }
+
+  &__empty {
+    @include text-md;
+    @include text-secondary;
+  }
 }

--- a/src/components/DatasetDetailsPage/DatasetSpecificationSection/DatasetSpecificationSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSpecificationSection/DatasetSpecificationSection.tsx
@@ -15,59 +15,47 @@ interface SpecificationItem {
 export default function DatasetSpecificationSection({
   specification,
 }: DatasetSpecificationSectionProps) {
-  const items: SpecificationItem[] = [
-    {
-      label: "Total Records:",
-      value: specification?.totalRecords || "782 records",
-    },
-    {
-      label: "Time range:",
-      value:
-        specification?.timeRange ||
-        "January 1, 2001 to December 31, 2022 (22 years)",
-    },
-    {
-      label: "Geographic Coverage:",
-      value:
-        specification?.geographicCoverage ||
-        "Global (Latitude: -61.85° to 71.63°, Longitude: -179.97° to 179.66°)",
-    },
-    {
-      label: "Population Density:",
-      value:
-        specification?.populationDensity ||
-        "Varies by region, average of 55 people per km².",
-    },
-    {
-      label: "Climate Zones:",
-      value:
-        specification?.climateZones || "Tropical, Temperate, Arid, and Polar.",
-    },
+  const candidates: { label: string; value?: string }[] = [
+    { label: "Total Records:", value: specification?.totalRecords },
+    { label: "Time range:", value: specification?.timeRange },
+    { label: "Geographic Coverage:", value: specification?.geographicCoverage },
+    { label: "Population Density:", value: specification?.populationDensity },
+    { label: "Climate Zones:", value: specification?.climateZones },
     {
       label: "Key Biodiversity Areas:",
-      value:
-        specification?.keyBiodiversityAreas ||
-        "Amazon Rainforest, Coral Reefs, Himalayas.",
+      value: specification?.keyBiodiversityAreas,
     },
   ];
+  const items: SpecificationItem[] = candidates.filter(
+    (item): item is SpecificationItem => Boolean(item.value?.trim()),
+  );
 
   return (
     <div className={styles.datasetSpecificationSection}>
       <h3 className={styles.datasetSpecificationSection__title}>
         Specification
       </h3>
-      <div className={styles.datasetSpecificationSection__list}>
-        {items.map((item, index) => (
-          <div key={index} className={styles.datasetSpecificationSection__item}>
-            <span className={styles.datasetSpecificationSection__label}>
-              {item.label}
-            </span>
-            <span className={styles.datasetSpecificationSection__value}>
-              {item.value}
-            </span>
-          </div>
-        ))}
-      </div>
+      {items.length > 0 ? (
+        <div className={styles.datasetSpecificationSection__list}>
+          {items.map((item) => (
+            <div
+              key={item.label}
+              className={styles.datasetSpecificationSection__item}
+            >
+              <span className={styles.datasetSpecificationSection__label}>
+                {item.label}
+              </span>
+              <span className={styles.datasetSpecificationSection__value}>
+                {item.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className={styles.datasetSpecificationSection__empty}>
+          No specification available for this dataset.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/DatasetDetailsPage/DatasetUseCasesSection/DatasetUseCasesSection.module.scss
+++ b/src/components/DatasetDetailsPage/DatasetUseCasesSection/DatasetUseCasesSection.module.scss
@@ -15,6 +15,11 @@
     word-break: break-word;
   }
 
+  &__empty {
+    @include text-md;
+    @include text-secondary;
+  }
+
   &__list {
     list-style: disc;
     padding-left: 20px;

--- a/src/components/DatasetDetailsPage/DatasetUseCasesSection/DatasetUseCasesSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetUseCasesSection/DatasetUseCasesSection.tsx
@@ -10,56 +10,22 @@ interface DatasetUseCasesSectionProps {
 export default function DatasetUseCasesSection({
   useCases,
 }: DatasetUseCasesSectionProps) {
-  const defaultUseCases = (
-    <ul className={styles.datasetUseCasesSection__list}>
-      <li className={styles.datasetUseCasesSection__item}>
-        <span className={styles.datasetUseCasesSection__itemTitle}>
-          Weather Prediction Models:
-        </span>
-        <span>
-          {" "}
-          Researchers and data scientists can use this dataset to develop and
-          train weather prediction models for various locations.
-        </span>
-      </li>
-      <li className={styles.datasetUseCasesSection__item}>
-        <span className={styles.datasetUseCasesSection__itemTitle}>
-          Climate Studies:
-        </span>
-        <span>
-          {" "}
-          The dataset can be used for climate studies and analysis to understand
-          weather patterns and trends in different regions.
-        </span>
-      </li>
-      <li className={styles.datasetUseCasesSection__item}>
-        <span className={styles.datasetUseCasesSection__itemTitle}>
-          Educational Purposes:
-        </span>
-        <span>
-          {" "}
-          Students and educators can use this dataset to learn about data
-          analysis, visualization, and modeling techniques in the context of
-          weather data.
-        </span>
-      </li>
-    </ul>
-  );
-
   return (
     <div className={styles.datasetUseCasesSection}>
       <h3 className={styles.datasetUseCasesSection__title}>
         Potential Use Cases
       </h3>
       <div className={styles.datasetUseCasesSection__content}>
-        {useCases ? (
+        {useCases?.trim() ? (
           <FormattedText
             as="div"
             className={styles.datasetUseCasesSection__text}
             text={useCases}
           />
         ) : (
-          defaultUseCases
+          <p className={styles.datasetUseCasesSection__empty}>
+            No use-case information available.
+          </p>
         )}
       </div>
     </div>


### PR DESCRIPTION
Closes #182.

## Summary

On the Dataset Details page (`/datasets/[id]`) the **Specification** card and the **Potential Use Cases** section rendered static placeholder text whenever the API did not return those fields. Because the gateway does not populate them for most datasets, every dataset showed the exact same fake values (e.g. `782 records`, `Global (Latitude: -61.85° …)`, `Weather Prediction Models`, `Climate Studies`).

## Changes

- **`DatasetSpecificationSection`** — removed all hardcoded fallback strings. It now renders only the spec fields that carry a real value; when none are present it shows a neutral empty state: *"No specification available for this dataset."*
- **`DatasetUseCasesSection`** — removed the hardcoded `defaultUseCases` block. It renders the API-provided `useCases` (via `FormattedText`) or, when absent, an empty state: *"No use-case information available."*
- Added a shared `&__empty` style (`text-md` / `text-secondary`) to both `.module.scss` files, consistent with existing design tokens.

The data mapping in `datasets/[id]/page.tsx` already reads these fields from the API, so real values continue to render when the backend provides them.

## Verification

- Type-check clean; Biome clean; pre-commit hook (lint-staged + biome + type-check + tests 104/104) passed.
- Dev server compiles `/datasets/[id]` → HTTP 200.
- No hardcoded placeholder strings remain in either component.
- Full visual flow (login → /browse → dataset details) to be confirmed in review; empty-state behaviour was chosen over hiding the sections.

