### PR TITLE
DG-256 | Empty-state placeholders for Language Analysis modules

### DIFF
--- a/src/app/use-case/language/analysis/page.tsx
+++ b/src/app/use-case/language/analysis/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FeatureEmptyState } from "@ui/FeatureEmptyState";
 import { ArrowLeft, Download } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -278,7 +279,7 @@ export default function LanguageAnalysisPage() {
         </div>
 
         {/* Term Frequency */}
-        {showTermFreq && termFreqData.length > 0 && (
+        {state && showTermFreq && (
           <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
             <div className="flex flex-col gap-1">
               <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4]">
@@ -288,106 +289,116 @@ export default function LanguageAnalysisPage() {
                 Most frequent tokens across selected documents
               </p>
             </div>
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-[#e2e8f0]">
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
-                    #
-                  </th>
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
-                    Token
-                  </th>
-                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
-                    Frequency
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[#e2e8f0]">
-                {termFreqData.map((row, i) => (
-                  <tr key={row.token}>
-                    <td className="py-3 text-[14px] text-[#8095ad]">{i + 1}</td>
-                    <td className="py-3 text-[14px] font-medium text-[#314158]">
-                      {row.token}
-                    </td>
-                    <td className="py-3 text-[14px] text-[#314158] text-right">
-                      {row.frequency.toLocaleString()}
-                    </td>
+            {termFreqData.length > 0 ? (
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-[#e2e8f0]">
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
+                      #
+                    </th>
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
+                      Token
+                    </th>
+                    <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
+                      Frequency
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-[#e2e8f0]">
+                  {termFreqData.map((row, i) => (
+                    <tr key={row.token}>
+                      <td className="py-3 text-[14px] text-[#8095ad]">
+                        {i + 1}
+                      </td>
+                      <td className="py-3 text-[14px] font-medium text-[#314158]">
+                        {row.token}
+                      </td>
+                      <td className="py-3 text-[14px] text-[#314158] text-right">
+                        {row.frequency.toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <FeatureEmptyState />
+            )}
           </div>
         )}
 
         {/* Sentiment Profile */}
-        {showSentiment && sentimentData && (
+        {state && showSentiment && (
           <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
             <div className="flex items-center gap-3">
               <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4] flex-1">
                 Sentiment Profile
               </h2>
-              {sentimentData.totalDocs > 0 && (
+              {sentimentData && sentimentData.totalDocs > 0 && (
                 <span className="inline-flex items-center px-3 h-6 rounded-full bg-[#f1f5f9] text-[12px] font-medium text-[#5b708f]">
                   {sentimentData.totalDocs.toLocaleString()} docs
                 </span>
               )}
             </div>
-            <div className="flex items-center gap-8">
-              <DonutChart data={sentimentData} />
-              <div className="flex flex-col gap-3 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="w-3 h-3 rounded-full bg-[#2b7fff] shrink-0" />
-                  <span className="flex-1 text-[14px] text-[#314158]">
-                    Positive
-                  </span>
-                  <span className="text-[14px] font-medium text-[#314158]">
-                    {Math.round(sentimentData.positive)}%
-                  </span>
+            {sentimentData && sentimentData.totalDocs > 0 ? (
+              <div className="flex items-center gap-8">
+                <DonutChart data={sentimentData} />
+                <div className="flex flex-col gap-3 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="w-3 h-3 rounded-full bg-[#2b7fff] shrink-0" />
+                    <span className="flex-1 text-[14px] text-[#314158]">
+                      Positive
+                    </span>
+                    <span className="text-[14px] font-medium text-[#314158]">
+                      {Math.round(sentimentData.positive)}%
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="w-3 h-3 rounded-full bg-[#94a3b8] shrink-0" />
+                    <span className="flex-1 text-[14px] text-[#314158]">
+                      Neutral
+                    </span>
+                    <span className="text-[14px] font-medium text-[#314158]">
+                      {Math.round(sentimentData.neutral)}%
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="w-3 h-3 rounded-full bg-[#f54900] shrink-0" />
+                    <span className="flex-1 text-[14px] text-[#314158]">
+                      Negative
+                    </span>
+                    <span className="text-[14px] font-medium text-[#314158]">
+                      {Math.round(sentimentData.negative)}%
+                    </span>
+                  </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <span className="w-3 h-3 rounded-full bg-[#94a3b8] shrink-0" />
-                  <span className="flex-1 text-[14px] text-[#314158]">
-                    Neutral
-                  </span>
-                  <span className="text-[14px] font-medium text-[#314158]">
-                    {Math.round(sentimentData.neutral)}%
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="w-3 h-3 rounded-full bg-[#f54900] shrink-0" />
-                  <span className="flex-1 text-[14px] text-[#314158]">
-                    Negative
-                  </span>
-                  <span className="text-[14px] font-medium text-[#314158]">
-                    {Math.round(sentimentData.negative)}%
-                  </span>
+                <div className="flex flex-col gap-3">
+                  <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
+                    <span className="text-[24px] font-semibold text-[#314158]">
+                      {sentimentData.avgSentiment >= 0 ? "+" : ""}
+                      {sentimentData.avgSentiment.toFixed(3)}
+                    </span>
+                    <span className="text-[12px] font-normal text-[#5b708f]">
+                      avg sentiment
+                    </span>
+                  </div>
+                  <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
+                    <span className="text-[24px] font-semibold text-[#314158]">
+                      {sentimentData.confidence.toFixed(3)}
+                    </span>
+                    <span className="text-[12px] font-normal text-[#5b708f]">
+                      confidence score
+                    </span>
+                  </div>
                 </div>
               </div>
-              <div className="flex flex-col gap-3">
-                <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
-                  <span className="text-[24px] font-semibold text-[#314158]">
-                    {sentimentData.avgSentiment >= 0 ? "+" : ""}
-                    {sentimentData.avgSentiment.toFixed(3)}
-                  </span>
-                  <span className="text-[12px] font-normal text-[#5b708f]">
-                    avg sentiment
-                  </span>
-                </div>
-                <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
-                  <span className="text-[24px] font-semibold text-[#314158]">
-                    {sentimentData.confidence.toFixed(3)}
-                  </span>
-                  <span className="text-[12px] font-normal text-[#5b708f]">
-                    confidence score
-                  </span>
-                </div>
-              </div>
-            </div>
+            ) : (
+              <FeatureEmptyState />
+            )}
           </div>
         )}
 
         {/* Collocations */}
-        {showCollocations && collocationData.length > 0 && (
+        {state && showCollocations && (
           <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
             <div className="flex flex-col gap-1">
               <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4]">
@@ -398,45 +409,51 @@ export default function LanguageAnalysisPage() {
                 information
               </p>
             </div>
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-[#e2e8f0]">
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
-                    #
-                  </th>
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
-                    Bigram
-                  </th>
-                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
-                    Frequency
-                  </th>
-                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
-                    PMI
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[#e2e8f0]">
-                {collocationData.map((row, i) => (
-                  <tr key={row.bigram}>
-                    <td className="py-3 text-[14px] text-[#8095ad]">{i + 1}</td>
-                    <td className="py-3 text-[14px] font-medium text-[#314158]">
-                      {row.bigram}
-                    </td>
-                    <td className="py-3 text-[14px] text-[#314158] text-right">
-                      {row.frequency}
-                    </td>
-                    <td className="py-3 text-[14px] text-[#314158] text-right">
-                      {row.pmi.toFixed(2)}
-                    </td>
+            {collocationData.length > 0 ? (
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-[#e2e8f0]">
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
+                      #
+                    </th>
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
+                      Bigram
+                    </th>
+                    <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
+                      Frequency
+                    </th>
+                    <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
+                      PMI
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-[#e2e8f0]">
+                  {collocationData.map((row, i) => (
+                    <tr key={row.bigram}>
+                      <td className="py-3 text-[14px] text-[#8095ad]">
+                        {i + 1}
+                      </td>
+                      <td className="py-3 text-[14px] font-medium text-[#314158]">
+                        {row.bigram}
+                      </td>
+                      <td className="py-3 text-[14px] text-[#314158] text-right">
+                        {row.frequency}
+                      </td>
+                      <td className="py-3 text-[14px] text-[#314158] text-right">
+                        {row.pmi.toFixed(2)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <FeatureEmptyState />
+            )}
           </div>
         )}
 
         {/* Retrieved Texts */}
-        {retrievedTexts.length > 0 && (
+        {state && (
           <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
             <div className="flex flex-col gap-1">
               <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4]">
@@ -449,49 +466,36 @@ export default function LanguageAnalysisPage() {
                 using all retrieved documents.
               </p>
             </div>
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-[#e2e8f0]">
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
-                    #
-                  </th>
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
-                    Text
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[#e2e8f0]">
-                {retrievedTexts.map((row, i) => (
-                  <tr key={i}>
-                    <td className="py-3 text-[14px] text-[#8095ad] align-top">
-                      {i + 1}
-                    </td>
-                    <td className="py-3 text-[14px] font-medium text-[#314158]">
-                      {row.content}
-                    </td>
+            {retrievedTexts.length > 0 ? (
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-[#e2e8f0]">
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
+                      #
+                    </th>
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
+                      Text
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-[#e2e8f0]">
+                  {retrievedTexts.map((row, i) => (
+                    <tr key={i}>
+                      <td className="py-3 text-[14px] text-[#8095ad] align-top">
+                        {i + 1}
+                      </td>
+                      <td className="py-3 text-[14px] font-medium text-[#314158]">
+                        {row.content}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <FeatureEmptyState />
+            )}
           </div>
         )}
-
-        {/* Empty state when no data and no features selected */}
-        {state &&
-          !termFreqData.length &&
-          !sentimentData &&
-          !collocationData.length &&
-          !retrievedTexts.length && (
-            <div className="bg-white border border-[#e2e8f0] rounded-2xl p-10 flex flex-col items-center gap-2">
-              <p className="text-[16px] font-medium text-[#314158]">
-                No analysis data available
-              </p>
-              <p className="text-[14px] text-[#5b708f]">
-                Try enabling analysis components or selecting datasets with more
-                data.
-              </p>
-            </div>
-          )}
       </div>
     </div>
   );

--- a/src/components/ui/FeatureEmptyState.tsx
+++ b/src/components/ui/FeatureEmptyState.tsx
@@ -1,0 +1,17 @@
+interface FeatureEmptyStateProps {
+  message?: string;
+  className?: string;
+}
+
+export function FeatureEmptyState({
+  message = "No results for this feature.",
+  className = "",
+}: FeatureEmptyStateProps) {
+  return (
+    <div
+      className={`flex items-center justify-center py-10 text-center text-[14px] text-slate-400 ${className}`}
+    >
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #256.

## Summary

On the Language Analysis subpage (`/use-case/language/analysis`) each analytical module previously **disappeared entirely** when its backend data was empty, and a single generic "No analysis data available" block covered the all-empty case. This PR gives every module its own graceful empty state.

## Changes

- **New reusable component** `src/components/ui/FeatureEmptyState.tsx` — lightweight, centered, muted (`text-slate-400`), default copy exactly **"No results for this feature."**
- Every active module now renders its card and **independently checks its data source**, falling back to the placeholder when the data is `null`/`undefined` or an empty array:

  | Module | Card shown when | Empty state when |
  |---|---|---|
  | Term Frequency | `state && showTermFreq` | `termFreqData.length === 0` |
  | Sentiment Profile | `state && showSentiment` | no data / `totalDocs === 0` |
  | Collocations | `state && showCollocations` | `collocationData.length === 0` |
  | Retrieved Texts | `state` (no feature toggle) | `retrievedTexts.length === 0` |

- Modules gated by a feature toggle still only appear when that feature was selected; the empty state is for a *selected* module that returned no data.
- Removed the old aggregate "No analysis data available" block, now superseded by per-module empty states.
- Card wrapper (border, padding, header) is preserved so layout structure and height stay consistent.

## Acceptance criteria

- ✅ Each module independently checks its data before rendering.
- ✅ Empty state triggered for `null` / `undefined` / `length === 0`.
- ✅ Fallback copy is exactly "No results for this feature."
- ✅ Clean, centered, muted (`text-slate-400`) inside the module's standard card.
- ✅ Reusable helper component.

## Verification

- Type-check clean; Biome clean.
- Dev server compiles `/use-case/language/analysis` → HTTP 200.
- End-to-end no-results flow (query e.g. `xyz123abc` → Start Analysis) to be confirmed in review; requires auth + vector-DB miss.


