### PR TITLE
Release v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gems-frontend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/src/app/use-case/language/analysis/page.tsx
+++ b/src/app/use-case/language/analysis/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FeatureEmptyState } from "@ui/FeatureEmptyState";
 import { ArrowLeft, Download } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -26,7 +27,6 @@ interface CollocationRow {
 
 interface RetrievedTextRow {
   content: string;
-  similarity: number;
 }
 
 interface AnalysisState {
@@ -145,7 +145,6 @@ function mapResponse(
     .slice(0, 10)
     .map((r) => ({
       content: String(r.content),
-      similarity: Number(r.similarity ?? 0),
     }));
 
   return { termFreqData, sentimentData, collocationData, retrievedTexts };
@@ -280,7 +279,7 @@ export default function LanguageAnalysisPage() {
         </div>
 
         {/* Term Frequency */}
-        {showTermFreq && termFreqData.length > 0 && (
+        {state && showTermFreq && (
           <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
             <div className="flex flex-col gap-1">
               <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4]">
@@ -290,106 +289,116 @@ export default function LanguageAnalysisPage() {
                 Most frequent tokens across selected documents
               </p>
             </div>
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-[#e2e8f0]">
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
-                    #
-                  </th>
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
-                    Token
-                  </th>
-                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
-                    Frequency
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[#e2e8f0]">
-                {termFreqData.map((row, i) => (
-                  <tr key={row.token}>
-                    <td className="py-3 text-[14px] text-[#8095ad]">{i + 1}</td>
-                    <td className="py-3 text-[14px] font-medium text-[#314158]">
-                      {row.token}
-                    </td>
-                    <td className="py-3 text-[14px] text-[#314158] text-right">
-                      {row.frequency.toLocaleString()}
-                    </td>
+            {termFreqData.length > 0 ? (
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-[#e2e8f0]">
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
+                      #
+                    </th>
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
+                      Token
+                    </th>
+                    <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
+                      Frequency
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-[#e2e8f0]">
+                  {termFreqData.map((row, i) => (
+                    <tr key={row.token}>
+                      <td className="py-3 text-[14px] text-[#8095ad]">
+                        {i + 1}
+                      </td>
+                      <td className="py-3 text-[14px] font-medium text-[#314158]">
+                        {row.token}
+                      </td>
+                      <td className="py-3 text-[14px] text-[#314158] text-right">
+                        {row.frequency.toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <FeatureEmptyState />
+            )}
           </div>
         )}
 
         {/* Sentiment Profile */}
-        {showSentiment && sentimentData && (
+        {state && showSentiment && (
           <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
             <div className="flex items-center gap-3">
               <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4] flex-1">
                 Sentiment Profile
               </h2>
-              {sentimentData.totalDocs > 0 && (
+              {sentimentData && sentimentData.totalDocs > 0 && (
                 <span className="inline-flex items-center px-3 h-6 rounded-full bg-[#f1f5f9] text-[12px] font-medium text-[#5b708f]">
                   {sentimentData.totalDocs.toLocaleString()} docs
                 </span>
               )}
             </div>
-            <div className="flex items-center gap-8">
-              <DonutChart data={sentimentData} />
-              <div className="flex flex-col gap-3 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="w-3 h-3 rounded-full bg-[#2b7fff] shrink-0" />
-                  <span className="flex-1 text-[14px] text-[#314158]">
-                    Positive
-                  </span>
-                  <span className="text-[14px] font-medium text-[#314158]">
-                    {Math.round(sentimentData.positive)}%
-                  </span>
+            {sentimentData && sentimentData.totalDocs > 0 ? (
+              <div className="flex items-center gap-8">
+                <DonutChart data={sentimentData} />
+                <div className="flex flex-col gap-3 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="w-3 h-3 rounded-full bg-[#2b7fff] shrink-0" />
+                    <span className="flex-1 text-[14px] text-[#314158]">
+                      Positive
+                    </span>
+                    <span className="text-[14px] font-medium text-[#314158]">
+                      {Math.round(sentimentData.positive)}%
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="w-3 h-3 rounded-full bg-[#94a3b8] shrink-0" />
+                    <span className="flex-1 text-[14px] text-[#314158]">
+                      Neutral
+                    </span>
+                    <span className="text-[14px] font-medium text-[#314158]">
+                      {Math.round(sentimentData.neutral)}%
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="w-3 h-3 rounded-full bg-[#f54900] shrink-0" />
+                    <span className="flex-1 text-[14px] text-[#314158]">
+                      Negative
+                    </span>
+                    <span className="text-[14px] font-medium text-[#314158]">
+                      {Math.round(sentimentData.negative)}%
+                    </span>
+                  </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <span className="w-3 h-3 rounded-full bg-[#94a3b8] shrink-0" />
-                  <span className="flex-1 text-[14px] text-[#314158]">
-                    Neutral
-                  </span>
-                  <span className="text-[14px] font-medium text-[#314158]">
-                    {Math.round(sentimentData.neutral)}%
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="w-3 h-3 rounded-full bg-[#f54900] shrink-0" />
-                  <span className="flex-1 text-[14px] text-[#314158]">
-                    Negative
-                  </span>
-                  <span className="text-[14px] font-medium text-[#314158]">
-                    {Math.round(sentimentData.negative)}%
-                  </span>
+                <div className="flex flex-col gap-3">
+                  <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
+                    <span className="text-[24px] font-semibold text-[#314158]">
+                      {sentimentData.avgSentiment >= 0 ? "+" : ""}
+                      {sentimentData.avgSentiment.toFixed(3)}
+                    </span>
+                    <span className="text-[12px] font-normal text-[#5b708f]">
+                      avg sentiment
+                    </span>
+                  </div>
+                  <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
+                    <span className="text-[24px] font-semibold text-[#314158]">
+                      {sentimentData.confidence.toFixed(3)}
+                    </span>
+                    <span className="text-[12px] font-normal text-[#5b708f]">
+                      confidence score
+                    </span>
+                  </div>
                 </div>
               </div>
-              <div className="flex flex-col gap-3">
-                <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
-                  <span className="text-[24px] font-semibold text-[#314158]">
-                    {sentimentData.avgSentiment >= 0 ? "+" : ""}
-                    {sentimentData.avgSentiment.toFixed(3)}
-                  </span>
-                  <span className="text-[12px] font-normal text-[#5b708f]">
-                    avg sentiment
-                  </span>
-                </div>
-                <div className="bg-[#f8fafc] border border-[#e2e8f0] rounded-xl p-4 flex flex-col gap-1">
-                  <span className="text-[24px] font-semibold text-[#314158]">
-                    {sentimentData.confidence.toFixed(3)}
-                  </span>
-                  <span className="text-[12px] font-normal text-[#5b708f]">
-                    confidence score
-                  </span>
-                </div>
-              </div>
-            </div>
+            ) : (
+              <FeatureEmptyState />
+            )}
           </div>
         )}
 
         {/* Collocations */}
-        {showCollocations && collocationData.length > 0 && (
+        {state && showCollocations && (
           <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
             <div className="flex flex-col gap-1">
               <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4]">
@@ -400,45 +409,51 @@ export default function LanguageAnalysisPage() {
                 information
               </p>
             </div>
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-[#e2e8f0]">
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
-                    #
-                  </th>
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
-                    Bigram
-                  </th>
-                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
-                    Frequency
-                  </th>
-                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
-                    PMI
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[#e2e8f0]">
-                {collocationData.map((row, i) => (
-                  <tr key={row.bigram}>
-                    <td className="py-3 text-[14px] text-[#8095ad]">{i + 1}</td>
-                    <td className="py-3 text-[14px] font-medium text-[#314158]">
-                      {row.bigram}
-                    </td>
-                    <td className="py-3 text-[14px] text-[#314158] text-right">
-                      {row.frequency}
-                    </td>
-                    <td className="py-3 text-[14px] text-[#314158] text-right">
-                      {row.pmi.toFixed(2)}
-                    </td>
+            {collocationData.length > 0 ? (
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-[#e2e8f0]">
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
+                      #
+                    </th>
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
+                      Bigram
+                    </th>
+                    <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
+                      Frequency
+                    </th>
+                    <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
+                      PMI
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-[#e2e8f0]">
+                  {collocationData.map((row, i) => (
+                    <tr key={row.bigram}>
+                      <td className="py-3 text-[14px] text-[#8095ad]">
+                        {i + 1}
+                      </td>
+                      <td className="py-3 text-[14px] font-medium text-[#314158]">
+                        {row.bigram}
+                      </td>
+                      <td className="py-3 text-[14px] text-[#314158] text-right">
+                        {row.frequency}
+                      </td>
+                      <td className="py-3 text-[14px] text-[#314158] text-right">
+                        {row.pmi.toFixed(2)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <FeatureEmptyState />
+            )}
           </div>
         )}
 
         {/* Retrieved Texts */}
-        {retrievedTexts.length > 0 && (
+        {state && (
           <div className="bg-white border border-[#e2e8f0] rounded-2xl p-5 flex flex-col gap-4">
             <div className="flex flex-col gap-1">
               <h2 className="text-[20px] font-semibold text-[#1d293d] leading-[1.4]">
@@ -451,55 +466,36 @@ export default function LanguageAnalysisPage() {
                 using all retrieved documents.
               </p>
             </div>
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-[#e2e8f0]">
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
-                    #
-                  </th>
-                  <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
-                    Text
-                  </th>
-                  <th className="text-right text-[12px] font-medium text-[#8095ad] pb-3">
-                    Similarity
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[#e2e8f0]">
-                {retrievedTexts.map((row, i) => (
-                  <tr key={i}>
-                    <td className="py-3 text-[14px] text-[#8095ad] align-top">
-                      {i + 1}
-                    </td>
-                    <td className="py-3 text-[14px] font-medium text-[#314158]">
-                      {row.content}
-                    </td>
-                    <td className="py-3 text-[14px] text-[#314158] text-right align-top">
-                      {row.similarity.toFixed(4)}
-                    </td>
+            {retrievedTexts.length > 0 ? (
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-[#e2e8f0]">
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3 w-10">
+                      #
+                    </th>
+                    <th className="text-left text-[12px] font-medium text-[#8095ad] pb-3">
+                      Text
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-[#e2e8f0]">
+                  {retrievedTexts.map((row, i) => (
+                    <tr key={i}>
+                      <td className="py-3 text-[14px] text-[#8095ad] align-top">
+                        {i + 1}
+                      </td>
+                      <td className="py-3 text-[14px] font-medium text-[#314158]">
+                        {row.content}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <FeatureEmptyState />
+            )}
           </div>
         )}
-
-        {/* Empty state when no data and no features selected */}
-        {state &&
-          !termFreqData.length &&
-          !sentimentData &&
-          !collocationData.length &&
-          !retrievedTexts.length && (
-            <div className="bg-white border border-[#e2e8f0] rounded-2xl p-10 flex flex-col items-center gap-2">
-              <p className="text-[16px] font-medium text-[#314158]">
-                No analysis data available
-              </p>
-              <p className="text-[14px] text-[#5b708f]">
-                Try enabling analysis components or selecting datasets with more
-                data.
-              </p>
-            </div>
-          )}
       </div>
     </div>
   );

--- a/src/components/DatasetDetailsPage/DatasetSpecificationSection/DatasetSpecificationSection.module.scss
+++ b/src/components/DatasetDetailsPage/DatasetSpecificationSection/DatasetSpecificationSection.module.scss
@@ -40,4 +40,9 @@
     @include text-secondary;
     flex: 1;
   }
+
+  &__empty {
+    @include text-md;
+    @include text-secondary;
+  }
 }

--- a/src/components/DatasetDetailsPage/DatasetSpecificationSection/DatasetSpecificationSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetSpecificationSection/DatasetSpecificationSection.tsx
@@ -15,59 +15,47 @@ interface SpecificationItem {
 export default function DatasetSpecificationSection({
   specification,
 }: DatasetSpecificationSectionProps) {
-  const items: SpecificationItem[] = [
-    {
-      label: "Total Records:",
-      value: specification?.totalRecords || "782 records",
-    },
-    {
-      label: "Time range:",
-      value:
-        specification?.timeRange ||
-        "January 1, 2001 to December 31, 2022 (22 years)",
-    },
-    {
-      label: "Geographic Coverage:",
-      value:
-        specification?.geographicCoverage ||
-        "Global (Latitude: -61.85° to 71.63°, Longitude: -179.97° to 179.66°)",
-    },
-    {
-      label: "Population Density:",
-      value:
-        specification?.populationDensity ||
-        "Varies by region, average of 55 people per km².",
-    },
-    {
-      label: "Climate Zones:",
-      value:
-        specification?.climateZones || "Tropical, Temperate, Arid, and Polar.",
-    },
+  const candidates: { label: string; value?: string }[] = [
+    { label: "Total Records:", value: specification?.totalRecords },
+    { label: "Time range:", value: specification?.timeRange },
+    { label: "Geographic Coverage:", value: specification?.geographicCoverage },
+    { label: "Population Density:", value: specification?.populationDensity },
+    { label: "Climate Zones:", value: specification?.climateZones },
     {
       label: "Key Biodiversity Areas:",
-      value:
-        specification?.keyBiodiversityAreas ||
-        "Amazon Rainforest, Coral Reefs, Himalayas.",
+      value: specification?.keyBiodiversityAreas,
     },
   ];
+  const items: SpecificationItem[] = candidates.filter(
+    (item): item is SpecificationItem => Boolean(item.value?.trim()),
+  );
 
   return (
     <div className={styles.datasetSpecificationSection}>
       <h3 className={styles.datasetSpecificationSection__title}>
         Specification
       </h3>
-      <div className={styles.datasetSpecificationSection__list}>
-        {items.map((item, index) => (
-          <div key={index} className={styles.datasetSpecificationSection__item}>
-            <span className={styles.datasetSpecificationSection__label}>
-              {item.label}
-            </span>
-            <span className={styles.datasetSpecificationSection__value}>
-              {item.value}
-            </span>
-          </div>
-        ))}
-      </div>
+      {items.length > 0 ? (
+        <div className={styles.datasetSpecificationSection__list}>
+          {items.map((item) => (
+            <div
+              key={item.label}
+              className={styles.datasetSpecificationSection__item}
+            >
+              <span className={styles.datasetSpecificationSection__label}>
+                {item.label}
+              </span>
+              <span className={styles.datasetSpecificationSection__value}>
+                {item.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className={styles.datasetSpecificationSection__empty}>
+          No specification available for this dataset.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/DatasetDetailsPage/DatasetUseCasesSection/DatasetUseCasesSection.module.scss
+++ b/src/components/DatasetDetailsPage/DatasetUseCasesSection/DatasetUseCasesSection.module.scss
@@ -15,6 +15,11 @@
     word-break: break-word;
   }
 
+  &__empty {
+    @include text-md;
+    @include text-secondary;
+  }
+
   &__list {
     list-style: disc;
     padding-left: 20px;

--- a/src/components/DatasetDetailsPage/DatasetUseCasesSection/DatasetUseCasesSection.tsx
+++ b/src/components/DatasetDetailsPage/DatasetUseCasesSection/DatasetUseCasesSection.tsx
@@ -10,56 +10,22 @@ interface DatasetUseCasesSectionProps {
 export default function DatasetUseCasesSection({
   useCases,
 }: DatasetUseCasesSectionProps) {
-  const defaultUseCases = (
-    <ul className={styles.datasetUseCasesSection__list}>
-      <li className={styles.datasetUseCasesSection__item}>
-        <span className={styles.datasetUseCasesSection__itemTitle}>
-          Weather Prediction Models:
-        </span>
-        <span>
-          {" "}
-          Researchers and data scientists can use this dataset to develop and
-          train weather prediction models for various locations.
-        </span>
-      </li>
-      <li className={styles.datasetUseCasesSection__item}>
-        <span className={styles.datasetUseCasesSection__itemTitle}>
-          Climate Studies:
-        </span>
-        <span>
-          {" "}
-          The dataset can be used for climate studies and analysis to understand
-          weather patterns and trends in different regions.
-        </span>
-      </li>
-      <li className={styles.datasetUseCasesSection__item}>
-        <span className={styles.datasetUseCasesSection__itemTitle}>
-          Educational Purposes:
-        </span>
-        <span>
-          {" "}
-          Students and educators can use this dataset to learn about data
-          analysis, visualization, and modeling techniques in the context of
-          weather data.
-        </span>
-      </li>
-    </ul>
-  );
-
   return (
     <div className={styles.datasetUseCasesSection}>
       <h3 className={styles.datasetUseCasesSection__title}>
         Potential Use Cases
       </h3>
       <div className={styles.datasetUseCasesSection__content}>
-        {useCases ? (
+        {useCases?.trim() ? (
           <FormattedText
             as="div"
             className={styles.datasetUseCasesSection__text}
             text={useCases}
           />
         ) : (
-          defaultUseCases
+          <p className={styles.datasetUseCasesSection__empty}>
+            No use-case information available.
+          </p>
         )}
       </div>
     </div>

--- a/src/components/ui/FeatureEmptyState.tsx
+++ b/src/components/ui/FeatureEmptyState.tsx
@@ -1,0 +1,17 @@
+interface FeatureEmptyStateProps {
+  message?: string;
+  className?: string;
+}
+
+export function FeatureEmptyState({
+  message = "No results for this feature.",
+  className = "",
+}: FeatureEmptyStateProps) {
+  return (
+    <div
+      className={`flex items-center justify-center py-10 text-center text-[14px] text-slate-400 ${className}`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/src/components/ui/user/DatasetPermissionsModal.test.tsx
+++ b/src/components/ui/user/DatasetPermissionsModal.test.tsx
@@ -1,11 +1,13 @@
 import {
   fireEvent,
-  render,
+  render as rtlRender,
   screen,
   waitFor,
   within,
 } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { ErrorProvider } from "@/contexts/ErrorContext";
 import { DatasetPermissionsModal } from "./DatasetPermissionsModal";
 
 const mockUseApi = vi.fn();
@@ -13,6 +15,10 @@ const mockUseApi = vi.fn();
 vi.mock("@/hooks/useApi", () => ({
   useApi: () => mockUseApi(),
 }));
+
+// The modal reports API failures through the ErrorContext toast.
+const render = (ui: ReactElement) =>
+  rtlRender(<ErrorProvider>{ui}</ErrorProvider>);
 
 describe("DatasetPermissionsModal", () => {
   it("updates group permissions via context grants", async () => {
@@ -107,7 +113,7 @@ describe("DatasetPermissionsModal", () => {
     );
 
     fireEvent.click(await screen.findByText("Invite by E-mail"));
-    const emailInput = screen.getByPlaceholderText("Enter e-mail");
+    const emailInput = screen.getByPlaceholderText("Email address");
     fireEvent.change(emailInput, { target: { value: "ada@example.com" } });
     fireEvent.click(screen.getByText("Invite"));
 
@@ -126,6 +132,47 @@ describe("DatasetPermissionsModal", () => {
         "dg_ds-download",
       );
     });
+  });
+
+  it("shows an error toast and keeps the switch state when the server rejects the change", async () => {
+    const assignGroupDatasetGrant = vi
+      .fn()
+      .mockRejectedValue(new Error("403 Forbidden"));
+
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      getGroupDatasetGrants: vi.fn().mockResolvedValue({ "dataset-1": [] }),
+      assignGroupDatasetGrant,
+      unassignGroupDatasetGrant: vi.fn().mockResolvedValue(undefined),
+      queryUsers: vi.fn().mockResolvedValue({ items: [] }),
+      getUserDatasetGrants: vi.fn().mockResolvedValue({}),
+      assignUserDatasetGrant: vi.fn().mockResolvedValue(undefined),
+      unassignUserDatasetGrant: vi.fn().mockResolvedValue(undefined),
+    });
+
+    render(
+      <DatasetPermissionsModal
+        isOpen
+        datasetId="dataset-1"
+        datasetName="Dataset One"
+        onClose={vi.fn()}
+      />,
+    );
+
+    const browseToggle = await screen.findByLabelText("Research Team Browse");
+    expect(browseToggle).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(browseToggle);
+
+    await waitFor(() => {
+      expect(assignGroupDatasetGrant).toHaveBeenCalled();
+      expect(
+        screen.getByText(/server rejected the permission change/i),
+      ).toBeInTheDocument();
+    });
+    expect(browseToggle).toHaveAttribute("aria-pressed", "false");
   });
 
   it("filters groups with Manage Groups selection", async () => {

--- a/src/components/ui/user/DatasetPermissionsModal.tsx
+++ b/src/components/ui/user/DatasetPermissionsModal.tsx
@@ -10,6 +10,7 @@ import {
   mapRolesToPermissions,
   type PermissionKey,
 } from "@/config/contextGrantRoles";
+import { useError } from "@/contexts/ErrorContext";
 import { useApi } from "@/hooks/useApi";
 import { logError, logWarn } from "@/lib/logger";
 import { ManageGroupsModal } from "./ManageGroupsModal";
@@ -42,7 +43,6 @@ interface DatasetPermissionsModalProps {
   datasetId: string;
   datasetName: string;
   onClose: () => void;
-  hasManageRights?: boolean;
 }
 
 function PermissionSwitch({
@@ -77,9 +77,9 @@ export function DatasetPermissionsModal({
   datasetId,
   datasetName,
   onClose,
-  hasManageRights = false,
 }: DatasetPermissionsModalProps) {
   const api = useApi();
+  const { showError } = useError();
   const {
     hasToken,
     queryUserGroups,
@@ -228,6 +228,9 @@ export function DatasetPermissionsModal({
       );
     } catch (error) {
       logError("Failed to update group permission", error);
+      showError(
+        "The server rejected the permission change. You may not have manage rights for this dataset.",
+      );
     }
   };
 
@@ -260,6 +263,9 @@ export function DatasetPermissionsModal({
       );
     } catch (error) {
       logError("Failed to update user permission", error);
+      showError(
+        "The server rejected the permission change. You may not have manage rights for this dataset.",
+      );
     }
   };
 
@@ -284,6 +290,9 @@ export function DatasetPermissionsModal({
       );
     } catch (error) {
       logError("Failed to revoke group access", error);
+      showError(
+        "The server rejected revoking access. You may not have manage rights for this dataset.",
+      );
     } finally {
       setRevokeGroupId(null);
     }
@@ -451,7 +460,7 @@ export function DatasetPermissionsModal({
                                   <PermissionSwitch
                                     checked={row.permissions[column.key]}
                                     ariaLabel={`${row.name} ${column.label}`}
-                                    disabled={isLoading || !hasManageRights}
+                                    disabled={isLoading}
                                     onChange={() =>
                                       handleGroupToggle(
                                         row.id,
@@ -463,7 +472,7 @@ export function DatasetPermissionsModal({
                                 </div>
                               ))}
                             </div>
-                            {hasManageRights && hasAnyPermission && (
+                            {hasAnyPermission && (
                               <button
                                 type="button"
                                 className="ml-2 text-[14px] text-red-550 hover:underline"
@@ -557,6 +566,7 @@ export function DatasetPermissionsModal({
                             setInviteEmail("");
                           } catch (error) {
                             logError("Failed to lookup invite user", error);
+                            showError("Failed to look up the invited user.");
                           } finally {
                             setIsInviteLookupLoading(false);
                           }

--- a/src/components/ui/user/RolesPermissionsSection.test.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render as rtlRender, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { ErrorProvider } from "@/contexts/ErrorContext";
 import RolesPermissionsSection from "./RolesPermissionsSection";
 
 const mockUseApi = vi.fn();
@@ -8,6 +10,10 @@ const mockPush = vi.fn();
 vi.mock("@/hooks/useApi", () => ({
   useApi: () => mockUseApi(),
 }));
+
+// The embedded DatasetPermissionsModal reports failures via ErrorContext.
+const render = (ui: ReactElement) =>
+  rtlRender(<ErrorProvider>{ui}</ErrorProvider>);
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
@@ -153,5 +159,129 @@ describe("RolesPermissionsSection", () => {
     expect(sortedA.compareDocumentPosition(sortedB)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+  });
+
+  it("shows the dataset id under the dataset name (DG-241)", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      getCurrentUserContextGrants: vi.fn().mockResolvedValue([
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-1",
+          role: "edit",
+        },
+      ]),
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      queryDatasets: vi.fn().mockResolvedValue({
+        items: [{ id: "dataset-1", name: "Dataset One" }],
+      }),
+      queryCollections: vi.fn().mockResolvedValue({ items: [] }),
+    });
+
+    render(<RolesPermissionsSection />);
+
+    expect(await screen.findByText("Dataset One")).toBeInTheDocument();
+    expect(screen.getByText("dataset-1")).toBeInTheDocument();
+  });
+
+  it("marks grants whose dataset no longer resolves and reports them next to the result count (DG-240)", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      getCurrentUserContextGrants: vi.fn().mockResolvedValue([
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-1",
+          role: "edit",
+        },
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-deleted",
+          role: "browse",
+        },
+      ]),
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      // The API only knows dataset-1; dataset-deleted is an orphaned grant.
+      queryDatasets: vi.fn().mockResolvedValue({
+        items: [{ id: "dataset-1", name: "Dataset One" }],
+      }),
+      queryCollections: vi.fn().mockResolvedValue({ items: [] }),
+    });
+
+    render(<RolesPermissionsSection />);
+
+    expect(await screen.findByText("Unknown dataset")).toBeInTheDocument();
+    expect(screen.getByText("dataset-deleted")).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 references a dataset that no longer exists/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/2 results/)).toBeInTheDocument();
+  });
+
+  it("keeps rows usable and reports a lookup failure instead of claiming datasets were deleted", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      getCurrentUserContextGrants: vi.fn().mockResolvedValue([
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-1",
+          role: "edit",
+        },
+      ]),
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      queryDatasets: vi.fn().mockRejectedValue(new Error("gateway 500")),
+      queryCollections: vi.fn().mockResolvedValue({ items: [] }),
+    });
+
+    render(<RolesPermissionsSection />);
+
+    // The ID stands in for the name (name line + ID line), not "Unknown dataset".
+    expect((await screen.findAllByText("dataset-1")).length).toBeGreaterThan(1);
+    expect(screen.queryByText("Unknown dataset")).toBeNull();
+    expect(
+      screen.getByText(/dataset names could not be loaded/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/no longer exist/)).toBeNull();
+  });
+
+  it("treats a returned dataset with a blank name as resolved, showing the id as the name", async () => {
+    mockUseApi.mockReturnValue({
+      hasToken: true,
+      getCurrentUserContextGrants: vi.fn().mockResolvedValue([
+        {
+          principalId: "group-1",
+          principalType: 1,
+          targetType: 0,
+          targetId: "dataset-1",
+          role: "edit",
+        },
+      ]),
+      queryUserGroups: vi.fn().mockResolvedValue({
+        items: [{ id: "group-1", name: "Research Team" }],
+      }),
+      queryDatasets: vi.fn().mockResolvedValue({
+        items: [{ id: "dataset-1", name: "" }],
+      }),
+      queryCollections: vi.fn().mockResolvedValue({ items: [] }),
+    });
+
+    render(<RolesPermissionsSection />);
+
+    expect((await screen.findAllByText("dataset-1")).length).toBeGreaterThan(1);
+    expect(screen.queryByText("Unknown dataset")).toBeNull();
+    expect(screen.queryByText(/no longer exist/)).toBeNull();
   });
 });

--- a/src/components/ui/user/RolesPermissionsSection.tsx
+++ b/src/components/ui/user/RolesPermissionsSection.tsx
@@ -35,6 +35,8 @@ type GrantRow = {
   targetId: string;
   targetName: string;
   targetType: string;
+  /** False when the grant references a target the API no longer returns (deleted or inaccessible). */
+  resolved: boolean;
   roles: string[];
   groupCount: number;
   groupIds: string[];
@@ -468,6 +470,10 @@ export default function RolesPermissionsSection() {
   const [collectionNames, setCollectionNames] = useState<
     Record<string, string>
   >({});
+  // True when the name lookup itself failed — rows must then stay interactive
+  // with the ID as the name instead of being misreported as deleted targets.
+  const [datasetLookupFailed, setDatasetLookupFailed] = useState(false);
+  const [collectionLookupFailed, setCollectionLookupFailed] = useState(false);
   const [datasetUploadedBy, setDatasetUploadedBy] = useState<
     Record<string, string | null>
   >({});
@@ -535,13 +541,23 @@ export default function RolesPermissionsSection() {
           }, {});
         setGroupNames(groupMap);
 
-        const datasetIds = grantsResult
-          .filter((grant) => grant.targetType === 0 && grant.targetId)
-          .map((grant) => grant.targetId as string);
-        const collectionIds = grantsResult
-          .filter((grant) => grant.targetType === 1 && grant.targetId)
-          .map((grant) => grant.targetId as string);
+        const datasetIds = Array.from(
+          new Set(
+            grantsResult
+              .filter((grant) => grant.targetType === 0 && grant.targetId)
+              .map((grant) => grant.targetId as string),
+          ),
+        );
+        const collectionIds = Array.from(
+          new Set(
+            grantsResult
+              .filter((grant) => grant.targetType === 1 && grant.targetId)
+              .map((grant) => grant.targetId as string),
+          ),
+        );
 
+        let datasetsFailed = false;
+        let collectionsFailed = false;
         const [datasetsResult, collectionsResult] = await Promise.all([
           datasetIds.length > 0
             ? queryDatasets({
@@ -556,6 +572,7 @@ export default function RolesPermissionsSection() {
                 logWarn("Failed to load dataset names for grants", {
                   error: errorMessage,
                 });
+                datasetsFailed = true;
                 return { items: [] };
               })
             : Promise.resolve({ items: [] }),
@@ -572,6 +589,7 @@ export default function RolesPermissionsSection() {
                 logWarn("Failed to load collection names for grants", {
                   error: errorMessage,
                 });
+                collectionsFailed = true;
                 return { items: [] };
               })
             : Promise.resolve({ items: [] }),
@@ -584,15 +602,12 @@ export default function RolesPermissionsSection() {
           name?: string;
           createdBy?: string | null;
         }>;
+        // Every returned item counts as resolved; a blank name falls back to
+        // the ID for display but must not be misreported as a deleted target.
         const datasetMap = datasetItems
-          .map((item) => ({
-            id: item.id ?? "",
-            name: item.name ?? "",
-            uploadedBy: item.createdBy ?? null,
-          }))
-          .filter((item) => item.id && item.name)
+          .filter((item) => item.id)
           .reduce((acc: Record<string, string>, item) => {
-            acc[item.id] = item.name;
+            acc[item.id as string] = item.name?.trim() || (item.id as string);
             return acc;
           }, {});
         const datasetUploadedByMap = datasetItems
@@ -607,14 +622,9 @@ export default function RolesPermissionsSection() {
           createdBy?: string | null;
         }>;
         const collectionMap = collectionItems
-          .map((item) => ({
-            id: item.id ?? "",
-            name: item.name ?? "",
-            uploadedBy: item.createdBy ?? null,
-          }))
-          .filter((item) => item.id && item.name)
+          .filter((item) => item.id)
           .reduce((acc: Record<string, string>, item) => {
-            acc[item.id] = item.name;
+            acc[item.id as string] = item.name?.trim() || (item.id as string);
             return acc;
           }, {});
         const collectionUploadedByMap = collectionItems
@@ -624,10 +634,31 @@ export default function RolesPermissionsSection() {
             return acc;
           }, {});
 
+        if (!datasetsFailed && datasetItems.length < datasetIds.length) {
+          logWarn("Dataset name lookup returned fewer items than requested", {
+            requested: datasetIds.length,
+            returned: datasetItems.length,
+          });
+        }
+        if (
+          !collectionsFailed &&
+          collectionItems.length < collectionIds.length
+        ) {
+          logWarn(
+            "Collection name lookup returned fewer items than requested",
+            {
+              requested: collectionIds.length,
+              returned: collectionItems.length,
+            },
+          );
+        }
+
         setDatasetNames(datasetMap);
         setCollectionNames(collectionMap);
         setDatasetUploadedBy(datasetUploadedByMap);
         setCollectionUploadedBy(collectionUploadedByMap);
+        setDatasetLookupFailed(datasetsFailed);
+        setCollectionLookupFailed(collectionsFailed);
       } catch (error) {
         if (cancelled) return;
         logError("Failed to load context grants", error);
@@ -688,12 +719,27 @@ export default function RolesPermissionsSection() {
     });
 
     return Array.from(grouped.values()).map((entry) => {
-      const targetName =
+      const lookupFailed =
         entry.targetType === 0
-          ? datasetNames[entry.targetId] || entry.targetId || "Unknown"
+          ? datasetLookupFailed
           : entry.targetType === 1
-            ? collectionNames[entry.targetId] || entry.targetId || "Unknown"
-            : entry.targetId || "Unknown";
+            ? collectionLookupFailed
+            : false;
+      const resolvedName =
+        entry.targetType === 0
+          ? datasetNames[entry.targetId]
+          : entry.targetType === 1
+            ? collectionNames[entry.targetId]
+            : undefined;
+      const kindLabel = TARGET_KIND_LABELS[entry.targetType] ?? "Unknown";
+      // A failed lookup says nothing about whether the target exists — keep
+      // the row fully usable and show the ID in place of the name.
+      const resolved = lookupFailed || Boolean(resolvedName);
+      const targetName =
+        resolvedName ||
+        (lookupFailed
+          ? entry.targetId
+          : `Unknown ${TARGET_KIND_LABELS[entry.targetType]?.toLowerCase() ?? "target"}`);
       const uploadedBy =
         entry.targetType === 0
           ? (datasetUploadedBy[entry.targetId] ?? null)
@@ -705,7 +751,8 @@ export default function RolesPermissionsSection() {
         id: `${entry.targetType}-${entry.targetId}`,
         targetId: entry.targetId,
         targetName,
-        targetType: TARGET_KIND_LABELS[entry.targetType] ?? "Unknown",
+        targetType: kindLabel,
+        resolved,
         roles: Array.from(entry.roles),
         groupCount: entry.groups.size,
         groupIds: Array.from(entry.groups),
@@ -713,8 +760,10 @@ export default function RolesPermissionsSection() {
       };
     });
   }, [
+    collectionLookupFailed,
     collectionNames,
     collectionUploadedBy,
+    datasetLookupFailed,
     datasetNames,
     datasetUploadedBy,
     grants,
@@ -742,7 +791,9 @@ export default function RolesPermissionsSection() {
         groupFilter.length === 0 ||
         row.groupIds.some((groupId) => groupFilter.includes(groupId));
       const matchesSearch =
-        !query || row.targetName.toLowerCase().includes(query);
+        !query ||
+        row.targetName.toLowerCase().includes(query) ||
+        row.targetId.toLowerCase().includes(query);
       return matchesType && matchesRole && matchesGroup && matchesSearch;
     });
   }, [
@@ -755,10 +806,22 @@ export default function RolesPermissionsSection() {
     typeFilter,
   ]);
 
+  const unresolvedCount = useMemo(
+    () => filteredRows.filter((row) => !row.resolved).length,
+    [filteredRows],
+  );
+
+  const activeKind = typeFilter === "collections" ? "collection" : "dataset";
+  const activeLookupFailed =
+    typeFilter === "collections" ? collectionLookupFailed : datasetLookupFailed;
+
   const getPermissionLabel = (row: GrantRow) => row.roles[0] ?? "";
 
   const getSortValue = (row: GrantRow, key: SortKey) => {
-    if (key === "assetName") return row.targetName.toLowerCase();
+    // Tiebreak equal names (e.g. several "Unknown dataset" rows) by the
+    // visible target ID so ordering matches what the user sees.
+    if (key === "assetName")
+      return `${row.targetName.toLowerCase()} ${row.targetId}`;
     if (key === "groupsAdded") return row.groupCount;
     if (key === "permission") return getPermissionLabel(row).toLowerCase();
     return "";
@@ -957,6 +1020,21 @@ export default function RolesPermissionsSection() {
           <div className="text-[14px] leading-[150%] text-gray-750">
             <span className="text-gray-650">Showing:</span>{" "}
             {filteredRows.length} results
+            {!isLoading && activeLookupFailed && (
+              <span className="text-gray-650">
+                {" "}
+                · {activeKind} names could not be loaded — showing identifiers
+              </span>
+            )}
+            {!isLoading && !activeLookupFailed && unresolvedCount > 0 && (
+              <span className="text-gray-650">
+                {" "}
+                ·{" "}
+                {unresolvedCount === 1
+                  ? `1 references a ${activeKind} that no longer exists or is inaccessible`
+                  : `${unresolvedCount} reference ${activeKind}s that no longer exist or are inaccessible`}
+              </span>
+            )}
           </div>
         </div>
 
@@ -1055,11 +1133,14 @@ export default function RolesPermissionsSection() {
                     const roles = row.roles;
                     const primaryRole = roles[0];
                     const extraCount = Math.max(roles.length - 1, 0);
+                    const isInteractiveDataset =
+                      row.resolved &&
+                      row.targetType.toLowerCase() === "dataset";
                     const hasEditRights =
-                      row.targetType.toLowerCase() === "dataset" &&
+                      isInteractiveDataset &&
                       (roles.includes("Edit") || roles.includes("Manage"));
                     const hasDeleteRights =
-                      row.targetType.toLowerCase() === "dataset" &&
+                      isInteractiveDataset &&
                       (roles.includes("Delete") || roles.includes("Manage"));
                     const groupsTooltip =
                       row.groupCount > 0
@@ -1074,24 +1155,20 @@ export default function RolesPermissionsSection() {
                         key={row.id}
                         role="row"
                         className={`grid grid-cols-[1fr_126px_180px_122px_137px] items-center h-14 border-b border-slate-200 last:border-b-0 ${
-                          row.targetType.toLowerCase() === "dataset"
+                          isInteractiveDataset
                             ? "cursor-pointer hover:bg-slate-50"
                             : ""
                         }`}
                         onClick={() => {
-                          if (row.targetType.toLowerCase() !== "dataset")
-                            return;
+                          if (!isInteractiveDataset) return;
                           setSelectedDataset({
                             id: row.targetId,
                             name: row.targetName,
                           });
                         }}
                       >
-                        <div
-                          className="px-4 text-[14px] text-gray-750 truncate"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          {row.targetType.toLowerCase() === "dataset" ? (
+                        <div className="px-4 min-w-0">
+                          {isInteractiveDataset ? (
                             <button
                               type="button"
                               onClick={(event) => {
@@ -1102,13 +1179,30 @@ export default function RolesPermissionsSection() {
                                   ),
                                 );
                               }}
-                              className="text-left hover:underline"
+                              className="block max-w-full truncate text-left text-[14px] text-gray-750 hover:underline"
                             >
                               {row.targetName}
                             </button>
                           ) : (
-                            row.targetName
+                            <div
+                              className={`truncate text-[14px] ${
+                                row.resolved
+                                  ? "text-gray-750"
+                                  : "italic text-gray-500"
+                              }`}
+                            >
+                              {row.targetName}
+                            </div>
                           )}
+                          <Tooltip
+                            content={row.targetId}
+                            position="top"
+                            delay={300}
+                          >
+                            <div className="truncate font-mono text-[12px] text-gray-500">
+                              {row.targetId}
+                            </div>
+                          </Tooltip>
                         </div>
                         <div className="px-4 flex items-center justify-center">
                           {row.groupCount > 0 && groupsTooltip ? (
@@ -1223,15 +1317,6 @@ export default function RolesPermissionsSection() {
         datasetId={selectedDataset?.id ?? ""}
         datasetName={selectedDataset?.name ?? "Dataset permissions"}
         onClose={() => setSelectedDataset(null)}
-        hasManageRights={Boolean(
-          selectedDataset &&
-            grants.some(
-              (g) =>
-                g.targetId === selectedDataset.id &&
-                g.targetType === 0 &&
-                (g.role?.toLowerCase().includes("manage") ?? false),
-            ),
-        )}
       />
       <ConfirmationModal
         isVisible={Boolean(deleteConfirmDataset)}


### PR DESCRIPTION
Changes since v0.2.0.

## Features
- Enable dataset permission editing and surface server-side rejections (DG-242, #246).
- Show dataset name and ID in the permissions table and flag orphaned grants (DG-241, #245).

## UI and content
- Add empty-state placeholders for the Language Analysis modules (DG-256, #259).
- Remove hardcoded text from the dataset Specification and Use-Cases sections (DG-182, #258).
- Remove the Similarity column from the Retrieved Texts module (DG-255, #257).

---
Image: `ghcr.io/datagems-eosc/dg-app-ui:v0.3.0`