### PR TITLE
DG-215 | Build amd64-only image to speed up CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -83,7 +80,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta_app_image.outputs.tags }}


### PR DESCRIPTION
Drops the `linux/arm64` build leg (and the now-unneeded QEMU setup) from `docker-publish.yml`, building **`linux/amd64` only**.

## Why
The multi-arch build spent most of its ~15-25 min on the **arm64 leg built under QEMU emulation** (`next build` is CPU-heavy and very slow emulated). Cutting arm64 removes the emulation entirely, roughly halving CI time and eliminating the occasional emulated-build flakiness.

## Safe because
- The image is only deployed to the DataGEMS k8s clusters, whose nodes are **amd64** (confirmed on PROD: pod reports `x86_64`; DEV is the same infrastructure — worth a quick confirm before the next DEV deploy).
- Trade-off: pulling the image to run as a container on an arm64 host (e.g. Apple Silicon, `docker run`) would use Docker's emulation. Local development uses `pnpm dev`, not the container, so this doesn't affect day-to-day work.

No change to tags (`vX.Y.Z` / `latest` / `develop`).