### PR TITLE
DG-222 | "Notification" feature flag for UI element visibility

### DIFF
--- a/src/components/UserProfile/UserProfile.tsx
+++ b/src/components/UserProfile/UserProfile.tsx
@@ -7,6 +7,7 @@ import RolesPermissionsSection from "@ui/user/RolesPermissionsSection";
 import TabsHeader from "@ui/user/TabsHeader";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
+import { useFeatureFlag } from "@/contexts/FeatureFlagsContext";
 import { useUser } from "@/contexts/UserContext";
 import { useApi } from "@/hooks/useApi";
 import { logError } from "@/lib/logger";
@@ -40,14 +41,25 @@ export default function UserProfile() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { userData } = useUser();
+  const notificationEnabled = useFeatureFlag("notification");
   const [activeTab, setActiveTab] = useState<ActiveTabType>("personal");
 
   useEffect(() => {
     const tab = searchParams.get(TAB_QUERY);
-    if (tab === "roles" || tab === "notifications" || tab === "personal") {
+    if (
+      tab === "roles" ||
+      tab === "personal" ||
+      (tab === "notifications" && notificationEnabled)
+    ) {
       setActiveTab(tab);
     }
-  }, [searchParams]);
+  }, [searchParams, notificationEnabled]);
+
+  useEffect(() => {
+    if (!notificationEnabled && activeTab === "notifications") {
+      setActiveTab("personal");
+    }
+  }, [notificationEnabled, activeTab]);
 
   const setActiveTabWithUrl = (tab: ActiveTabType) => {
     setActiveTab(tab);
@@ -252,7 +264,7 @@ export default function UserProfile() {
             />
           )}
 
-          {activeTab === "notifications" && (
+          {activeTab === "notifications" && notificationEnabled && (
             <PreferencesSection
               isLoading={isLoading}
               notifications={notifications}

--- a/src/components/ui/UserProfileDropdown.tsx
+++ b/src/components/ui/UserProfileDropdown.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { Bell, LogOut, Settings } from "lucide-react";
 import { APP_ROUTES } from "@/config/appUrls";
+import { useFeatureFlag } from "@/contexts/FeatureFlagsContext";
 import { createUrl } from "@/lib/utils";
 import { Avatar } from "./Avatar";
 import { Dropdown, DropdownItem } from "./Dropdown";
@@ -15,9 +18,13 @@ export function UserProfileDropdown({
   isMobile = false,
   onLogout,
 }: UserProfileDropdownProps) {
+  const notificationEnabled = useFeatureFlag("notification");
+
   return (
     <div className="flex items-center gap-3">
-      <Bell className="w-5 h-5 text-icon" />
+      <Bell
+        className={`w-5 h-5 text-icon ${notificationEnabled ? "" : "hidden"}`}
+      />
 
       {/* Profile Dropdown */}
       <Dropdown

--- a/src/components/ui/user/TabsHeader.test.tsx
+++ b/src/components/ui/user/TabsHeader.test.tsx
@@ -1,10 +1,23 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FeatureFlagsProvider } from "@/contexts/FeatureFlagsContext";
+import { FEATURE_FLAGS_STORAGE_KEY } from "@/lib/featureFlags/storage";
 import TabsHeader from "./TabsHeader";
 
+const renderTabs = (activeTab: "personal" | "notifications" | "roles") =>
+  render(
+    <FeatureFlagsProvider>
+      <TabsHeader activeTab={activeTab} setActiveTab={vi.fn()} />
+    </FeatureFlagsProvider>,
+  );
+
 describe("TabsHeader", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it("renders only supported tabs", () => {
-    render(<TabsHeader activeTab="personal" setActiveTab={vi.fn()} />);
+    renderTabs("personal");
 
     expect(screen.getByText("Personal settings")).toBeInTheDocument();
     expect(screen.getByText("Notifications")).toBeInTheDocument();
@@ -13,10 +26,30 @@ describe("TabsHeader", () => {
 
   it("invokes setActiveTab on click", () => {
     const setActiveTab = vi.fn();
-    render(<TabsHeader activeTab="personal" setActiveTab={setActiveTab} />);
+    render(
+      <FeatureFlagsProvider>
+        <TabsHeader activeTab="personal" setActiveTab={setActiveTab} />
+      </FeatureFlagsProvider>,
+    );
 
     fireEvent.click(screen.getByText("Notifications"));
 
     expect(setActiveTab).toHaveBeenCalledWith("notifications");
+  });
+
+  it("hides the Notifications tab when the notification flag is off", () => {
+    window.localStorage.setItem(
+      FEATURE_FLAGS_STORAGE_KEY,
+      JSON.stringify({ notification: false }),
+    );
+
+    renderTabs("personal");
+
+    expect(screen.getByText("Notifications").closest("button")).toHaveClass(
+      "hidden",
+    );
+    expect(
+      screen.getByText("Personal settings").closest("button"),
+    ).not.toHaveClass("hidden");
   });
 });

--- a/src/components/ui/user/TabsHeader.tsx
+++ b/src/components/ui/user/TabsHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Bell, FolderLock, type LucideIcon, UserRoundPen } from "lucide-react";
+import { useFeatureFlag } from "@/contexts/FeatureFlagsContext";
 
 type ActiveTab = "personal" | "notifications" | "roles";
 
@@ -34,16 +35,21 @@ const TABS: TabItem[] = [
 ];
 
 export default function TabsHeader({ activeTab, setActiveTab }: Props) {
+  const notificationEnabled = useFeatureFlag("notification");
+
   return (
     <div className="w-full border-b border-slate-200">
       <nav className="flex gap-4 overflow-x-auto">
         {TABS.map(({ key, icon: Icon, title }) => {
           const isActive = activeTab === key;
+          const isHidden = key === "notifications" && !notificationEnabled;
           return (
             <button
               key={key}
               onClick={() => setActiveTab(key)}
-              className="relative flex items-center gap-2 h-[55px] px-2 pb-[14px] whitespace-nowrap"
+              className={`relative flex items-center gap-2 h-[55px] px-2 pb-[14px] whitespace-nowrap ${
+                isHidden ? "hidden" : ""
+              }`}
             >
               <Icon
                 className={`w-[25px] h-[25px] ${

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -12,6 +12,7 @@ export type FeatureFlagId =
   | "useCaseLifelongLearning"
   | "useCaseLanguage"
   | "datasetOnboarding"
+  | "notification"
   | "pinnedDatasetWeather"
   | "pinnedDatasetLanguage"
   | "pinnedDatasetMath";
@@ -90,6 +91,11 @@ export const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = [
     id: "datasetOnboarding",
     label: "Dataset onboarding",
     defaults: enabledEverywhere(),
+  },
+  {
+    id: "notification",
+    label: "Notification",
+    defaults: disabledEverywhere(),
   },
   {
     id: "pinnedDatasetWeather",

--- a/tests/featureFlags.test.ts
+++ b/tests/featureFlags.test.ts
@@ -12,6 +12,7 @@ import { parseOverrides } from "../src/lib/featureFlags/storage";
 const DISABLED_EVERYWHERE = new Set([
   "customCollection",
   "generalChat",
+  "notification",
   "pinnedDatasetWeather",
   "pinnedDatasetLanguage",
   "pinnedDatasetMath",


### PR DESCRIPTION
Closes #222.

## Summary

Introduce a global **`notification`** feature flag that controls the visibility of notification-related UI. Toggling it from the feature-flags manager (`/feature-flags`) shows/hides the target elements **without unmounting them** from the DOM (conditional `hidden` class), per the ticket's critical note.

Default: **disabled on every environment** (playground / staging / production) — the elements are hidden until an admin enables the flag.

## Changes

- **`config/featureFlags.ts`** — register the `notification` flag (`FeatureFlagId` + `FEATURE_FLAGS`), label "Notification", `disabledEverywhere()`.
- **`ui/UserProfileDropdown.tsx`** — bind the header notification bell to the flag; apply a conditional `hidden` class when off (element stays in the DOM). Marked the component `"use client"` so it can read the flag.
- **`ui/user/TabsHeader.tsx`** — hide the "Notifications" tab button via a conditional `hidden` class when off; the node stays in the DOM but is not selectable.
- **`UserProfile/UserProfile.tsx`** — guard the Notifications panel render and the `?tab=notifications` deep link so the content is unreachable when the flag is off (falls back to Personal settings).
- **Tests** — `tests/featureFlags.test.ts`: add `notification` to the disabled-by-default policy set. `TabsHeader.test.tsx`: wrap renders in `FeatureFlagsProvider` (the component now reads the flag) and cover the hidden-tab case.

## Behavior

| Flag | Bell (header) | "Notifications" tab (settings) |
|---|---|---|
| off (default) | hidden (`display:none`, still mounted) | hidden, not selectable; panel unreachable |
| on | visible in standard position | visible; panel + deep link work |

## Verification

- Type-check clean; Biome clean.
- Node test gate `pnpm test`: 104/104 pass (policy test updated).
- `TabsHeader` unit tests 3/3 pass. No new regressions vs the `develop` baseline in the (pre-existing red) vitest unit suite.
- Dev server compiles `/feature-flags` and `/settings` → HTTP 200.
